### PR TITLE
Reorganise menus

### DIFF
--- a/1984/anonymous/index.html
+++ b/1984/anonymous/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1984/index.html
+++ b/1984/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1985/applin/index.html
+++ b/1985/applin/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1985/august/index.html
+++ b/1985/august/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1985/index.html
+++ b/1985/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1985/lycklama/index.html
+++ b/1985/lycklama/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1985/shapiro/index.html
+++ b/1985/shapiro/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/applin/index.html
+++ b/1986/applin/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/hague/index.html
+++ b/1986/hague/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/holloway/index.html
+++ b/1986/holloway/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/index.html
+++ b/1986/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/pawka/index.html
+++ b/1986/pawka/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/stein/index.html
+++ b/1986/stein/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1986/wall/index.html
+++ b/1986/wall/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1987/biggar/index.html
+++ b/1987/biggar/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1987/heckbert/index.html
+++ b/1987/heckbert/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1987/hines/index.html
+++ b/1987/hines/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1987/index.html
+++ b/1987/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1987/korn/index.html
+++ b/1987/korn/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1987/lievaart/index.html
+++ b/1987/lievaart/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1987/wall/index.html
+++ b/1987/wall/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1987/westley/index.html
+++ b/1987/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/applin/index.html
+++ b/1988/applin/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/index.html
+++ b/1988/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/isaak/index.html
+++ b/1988/isaak/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/litmaath/index.html
+++ b/1988/litmaath/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/phillipps/index.html
+++ b/1988/phillipps/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/reddy/index.html
+++ b/1988/reddy/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/robison/index.html
+++ b/1988/robison/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/spinellis/index.html
+++ b/1988/spinellis/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1988/westley/index.html
+++ b/1988/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/index.html
+++ b/1989/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/jar.1/index.html
+++ b/1989/jar.1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/jar.2/index.html
+++ b/1989/jar.2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/ovdluhe/index.html
+++ b/1989/ovdluhe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/paul/index.html
+++ b/1989/paul/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/roemer/index.html
+++ b/1989/roemer/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/tromp/index.html
+++ b/1989/tromp/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/vanb/index.html
+++ b/1989/vanb/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/cmills/index.html
+++ b/1990/cmills/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/dds/index.html
+++ b/1990/dds/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/dg/index.html
+++ b/1990/dg/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/index.html
+++ b/1990/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/jaw/index.html
+++ b/1990/jaw/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/pjr/index.html
+++ b/1990/pjr/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/scjones/index.html
+++ b/1990/scjones/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/stig/index.html
+++ b/1990/stig/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/ant/index.html
+++ b/1991/ant/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/brnstnd/index.html
+++ b/1991/brnstnd/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/brnstnd/sorta.README.html
+++ b/1991/brnstnd/sorta.README.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/cdupont/index.html
+++ b/1991/cdupont/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/davidguy/index.html
+++ b/1991/davidguy/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/dds/index.html
+++ b/1991/dds/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/fine/index.html
+++ b/1991/fine/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/index.html
+++ b/1991/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/rince/index.html
+++ b/1991/rince/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/ant/index.html
+++ b/1992/ant/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/buzzard.1/index.html
+++ b/1992/buzzard.1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/buzzard.2/buzzard.2.README.html
+++ b/1992/buzzard.2/buzzard.2.README.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/buzzard.2/buzzard.2.design.html
+++ b/1992/buzzard.2/buzzard.2.design.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/buzzard.2/index.html
+++ b/1992/buzzard.2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/imc/index.html
+++ b/1992/imc/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/index.html
+++ b/1992/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/marangon/index.html
+++ b/1992/marangon/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/nathan/index.html
+++ b/1992/nathan/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/dgibson/index.html
+++ b/1993/dgibson/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/ejb/hanoi.html
+++ b/1993/ejb/hanoi.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/ejb/index.html
+++ b/1993/ejb/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/ejb/patience.html
+++ b/1993/ejb/patience.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/index.html
+++ b/1993/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/jonth/index.html
+++ b/1993/jonth/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/leo/index.html
+++ b/1993/leo/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/plummer/index.html
+++ b/1993/plummer/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/rince/design.html
+++ b/1993/rince/design.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/rince/index.html
+++ b/1993/rince/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/dodsond1/index.html
+++ b/1994/dodsond1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/horton/index.html
+++ b/1994/horton/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/imc/index.html
+++ b/1994/imc/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/index.html
+++ b/1994/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/shapiro/shapiro.html
+++ b/1994/shapiro/shapiro.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/smr/index.html
+++ b/1994/smr/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1994/westley/index.html
+++ b/1994/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/dodsond1/index.html
+++ b/1995/dodsond1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/dodsond2/index.html
+++ b/1995/dodsond2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/esde/index.html
+++ b/1995/esde/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/garry/index.html
+++ b/1995/garry/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/heathbar/index.html
+++ b/1995/heathbar/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/index.html
+++ b/1995/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/leo/secret.html
+++ b/1995/leo/secret.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/makarios/index.html
+++ b/1995/makarios/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/schnitzi/index.html
+++ b/1995/schnitzi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/spinellis/index.html
+++ b/1995/spinellis/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/dalbec/index.html
+++ b/1996/dalbec/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/eldby/index.html
+++ b/1996/eldby/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/index.html
+++ b/1996/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/rcm/index.html
+++ b/1996/rcm/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/schweikh1/index.html
+++ b/1996/schweikh1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/schweikh2/index.html
+++ b/1996/schweikh2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/schweikh3/index.html
+++ b/1996/schweikh3/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1996/westley/index.html
+++ b/1996/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/banks/index.html
+++ b/1998/banks/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/bas1/index.html
+++ b/1998/bas1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/bas2/index.html
+++ b/1998/bas2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/chaos/index.html
+++ b/1998/chaos/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/df/index.html
+++ b/1998/df/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/dorssel/index.html
+++ b/1998/dorssel/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/fanf/index.html
+++ b/1998/fanf/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/index.html
+++ b/1998/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/schweikh1/index.html
+++ b/1998/schweikh1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/schweikh1/macos.html
+++ b/1998/schweikh1/macos.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/schweikh2/index.html
+++ b/1998/schweikh2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/1998/tomtorfs/index.html
+++ b/1998/tomtorfs/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/anderson/index.html
+++ b/2000/anderson/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/bellard/index.html
+++ b/2000/bellard/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/bmeyer/index.html
+++ b/2000/bmeyer/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/briddlebane/index.html
+++ b/2000/briddlebane/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/dhyang/index.html
+++ b/2000/dhyang/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/index.html
+++ b/2000/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/jarijyrki/index.html
+++ b/2000/jarijyrki/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/natori/index.html
+++ b/2000/natori/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/robison/index.html
+++ b/2000/robison/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/schneiderwent/index.html
+++ b/2000/schneiderwent/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/thadgavin/index.html
+++ b/2000/thadgavin/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2000/tomx/index.html
+++ b/2000/tomx/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/coupard/index.html
+++ b/2001/coupard/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/ctk/index.html
+++ b/2001/ctk/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/herrmann2/index.html
+++ b/2001/herrmann2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/index.html
+++ b/2001/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/jason/index.html
+++ b/2001/jason/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/arachnid/index.html
+++ b/2004/arachnid/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/burley/index.html
+++ b/2004/burley/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/gavare/index.html
+++ b/2004/gavare/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/gavin/gavin.html
+++ b/2004/gavin/gavin.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/hibachi/index.html
+++ b/2004/hibachi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/hoyle/index.html
+++ b/2004/hoyle/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/index.html
+++ b/2004/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/kopczynski/index.html
+++ b/2004/kopczynski/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/newbern/index.html
+++ b/2004/newbern/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/omoikane/index.html
+++ b/2004/omoikane/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/schnitzi/index.html
+++ b/2004/schnitzi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/vik1/index.html
+++ b/2004/vik1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2004/vik2/index.html
+++ b/2004/vik2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/aidan/index.html
+++ b/2005/aidan/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/boutines/index.html
+++ b/2005/boutines/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/chia/index.html
+++ b/2005/chia/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/index.html
+++ b/2005/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/jetro/index.html
+++ b/2005/jetro/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/klausler/index.html
+++ b/2005/klausler/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/persano/index.html
+++ b/2005/persano/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/timwi/index.html
+++ b/2005/timwi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/toledo/index.html
+++ b/2005/toledo/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/vik/index.html
+++ b/2005/vik/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2005/vince/index.html
+++ b/2005/vince/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/grothe/index.html
+++ b/2006/grothe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/hamre/index.html
+++ b/2006/hamre/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/index.html
+++ b/2006/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/meyer/index.html
+++ b/2006/meyer/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/night/index.html
+++ b/2006/night/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/sloane/index.html
+++ b/2006/sloane/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/stewart/index.html
+++ b/2006/stewart/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/sykes2/index.html
+++ b/2006/sykes2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/toledo1/index.html
+++ b/2006/toledo1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2006/toledo3/index.html
+++ b/2006/toledo3/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/akari/index.html
+++ b/2011/akari/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/blakely/index.html
+++ b/2011/blakely/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/eastman/index.html
+++ b/2011/eastman/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/goren/index.html
+++ b/2011/goren/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/hamaji/index.html
+++ b/2011/hamaji/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/hou/index.html
+++ b/2011/hou/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/index.html
+++ b/2011/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/konno/index.html
+++ b/2011/konno/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/toledo/index.html
+++ b/2011/toledo/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2011/zucker/index.html
+++ b/2011/zucker/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/deckmyn/deckmyn.html
+++ b/2012/deckmyn/deckmyn.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/endoh1/index.html
+++ b/2012/endoh1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/endoh2/index.html
+++ b/2012/endoh2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/grothe/index.html
+++ b/2012/grothe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/hamano/index.html
+++ b/2012/hamano/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/hou/hint.html
+++ b/2012/hou/hint.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/hou/index.html
+++ b/2012/hou/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/index.html
+++ b/2012/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/kang/index.html
+++ b/2012/kang/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/konno/index.html
+++ b/2012/konno/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/omoikane/index.html
+++ b/2012/omoikane/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/tromp/how.html
+++ b/2012/tromp/how.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2012/zeitak/index.html
+++ b/2012/zeitak/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/birken/index.html
+++ b/2013/birken/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/cable1/index.html
+++ b/2013/cable1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/cable3/index.html
+++ b/2013/cable3/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/endoh2/index.html
+++ b/2013/endoh2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/hou/doc/example.html
+++ b/2013/hou/doc/example.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/index.html
+++ b/2013/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/misaka/index.html
+++ b/2013/misaka/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/morgan1/index.html
+++ b/2013/morgan1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/morgan2/index.html
+++ b/2013/morgan2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2013/robison/index.html
+++ b/2013/robison/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/birken/index.html
+++ b/2014/birken/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/deak/index.html
+++ b/2014/deak/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/endoh1/index.html
+++ b/2014/endoh1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/endoh1/quine-qr.html
+++ b/2014/endoh1/quine-qr.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/endoh2/index.html
+++ b/2014/endoh2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/index.html
+++ b/2014/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/morgan/index.html
+++ b/2014/morgan/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/sinon/index.html
+++ b/2014/sinon/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/skeggs/index.html
+++ b/2014/skeggs/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2014/wiedijk/index.html
+++ b/2014/wiedijk/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/burton/index.html
+++ b/2015/burton/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/burton/obfuscation.html
+++ b/2015/burton/obfuscation.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/burton/road.to.obscurity.html
+++ b/2015/burton/road.to.obscurity.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/dogon/index.html
+++ b/2015/dogon/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/duble/index.html
+++ b/2015/duble/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/endoh1/index.html
+++ b/2015/endoh1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/endoh2/index.html
+++ b/2015/endoh2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/endoh3/index.html
+++ b/2015/endoh3/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/endoh4/index.html
+++ b/2015/endoh4/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/howe/index.html
+++ b/2015/howe/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/index.html
+++ b/2015/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/mills1/index.html
+++ b/2015/mills1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/muth/index.html
+++ b/2015/muth/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2015/yang/index.html
+++ b/2015/yang/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/anderson/index.html
+++ b/2018/anderson/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/bellard/index.html
+++ b/2018/bellard/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/burton1/index.html
+++ b/2018/burton1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/burton2/discrepancies.html
+++ b/2018/burton2/discrepancies.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/burton2/index.html
+++ b/2018/burton2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/endoh1/index.html
+++ b/2018/endoh1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/endoh2/index.html
+++ b/2018/endoh2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/ferguson/index.html
+++ b/2018/ferguson/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/ferguson/rpm.html
+++ b/2018/ferguson/rpm.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/giles/index.html
+++ b/2018/giles/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/index.html
+++ b/2018/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/poikola/index.html
+++ b/2018/poikola/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2018/yang/index.html
+++ b/2018/yang/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/diels-grabsch1/index.html
+++ b/2019/diels-grabsch1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/diels-grabsch2/index.html
+++ b/2019/diels-grabsch2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/giles/index.html
+++ b/2019/giles/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/index.html
+++ b/2019/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/endoh1/index.html
+++ b/2020/endoh1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/endoh2/index.html
+++ b/2020/endoh2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/endoh2/obfuscation/index.html
+++ b/2020/endoh2/obfuscation/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/endoh3/index.html
+++ b/2020/endoh3/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/COMPILING.html
+++ b/2020/ferguson1/COMPILING.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/HACKING.html
+++ b/2020/ferguson1/HACKING.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/bugs.html
+++ b/2020/ferguson1/bugs.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/cannibalism.log.html
+++ b/2020/ferguson1/cannibalism.log.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/chocolate-cake.html
+++ b/2020/ferguson1/chocolate-cake.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/crazy.log.html
+++ b/2020/ferguson1/crazy.log.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/gameplay.html
+++ b/2020/ferguson1/gameplay.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/obfuscation.html
+++ b/2020/ferguson1/obfuscation.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/terminals.html
+++ b/2020/ferguson1/terminals.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson1/troubleshooting.html
+++ b/2020/ferguson1/troubleshooting.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson2/obfuscation.html
+++ b/2020/ferguson2/obfuscation.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson2/recode.html
+++ b/2020/ferguson2/recode.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/ferguson2/testing-procedure.html
+++ b/2020/ferguson2/testing-procedure.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/index.html
+++ b/2020/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/kurdyukov1/index.html
+++ b/2020/kurdyukov1/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/kurdyukov2/index.html
+++ b/2020/kurdyukov2/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/kurdyukov3/index.html
+++ b/2020/kurdyukov3/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/kurdyukov4/index.html
+++ b/2020/kurdyukov4/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/tsoj/index.html
+++ b/2020/tsoj/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/2020/yang/index.html
+++ b/2020/yang/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/CODE_OF_CONDUCT.html
+++ b/CODE_OF_CONDUCT.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ clobber:
 	thanks gen_other_html quick_other_html quick_entry_index find_invalid_json \
 	gen_year_index quick_year_index quick_www www untar_entry_tarball untar_year_tarball \
 	form_entry_tarball form_year_tarball tar gen_status gen_sitemap \
-	sitemap timestamp update csv2entry entry2csv
+	sitemap timestamp update csv2entry entry2csv about contact
 
 # Suggest rules in this section
 #
@@ -632,9 +632,12 @@ about: ${GEN_TOP_HTML} about.md
 	@echo "You wonder what this is all about?"
 	@${GEN_TOP_HTML} about
 	@echo
-	@echo "You better not, because if you find out,"
-	@echo "it will instantly be replaced by something"
-	@echo "even more bizarre and inexplicable!"
+	@echo "You better not find out, because if you"
+	@echo "find out, it will instantly be replaced"
+	@echo "by something even more bizarre and"
+	@echo "inexplicable!"
+	@echo
+	@echo "Nobody wants that, do they?"
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
 # generate contact.html

--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,8 @@ help:
 	@echo '# Rules for building specific web pages, a subset of rules mentioned above:'
 	@echo
 	@echo 'make bugs		;: generate bugs.html'
+	@echo 'make about		;: generate about.html'
+	@echo 'make contact		;: generate contact.html'
 	@echo 'make faq		;: generate faq.html'
 	@echo 'make guidelines		;: generate next/guidelines.hmtl'
 	@echo 'make markdown		;: generate markdown.hmtl'
@@ -618,6 +620,34 @@ test:
 
 .PHONY: thanks bugs gen_next rules guidelines faq
 
+# generate about.html
+#
+# What is this all about? It is better that you do not decipher what this is all
+# about because if anyone ever does discover exactly what the IOCCC is for and
+# why it is here, it will instantly disappear and be replaced by something even
+# more bizarre and inexplicable!
+#
+about: ${GEN_TOP_HTML} about.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	@echo "You wonder what this is all about?"
+	@${GEN_TOP_HTML} about
+	@echo
+	@echo "You better not, because if you find out,"
+	@echo "it will instantly be replaced by something"
+	@echo "even more bizarre and inexplicable!"
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+# generate contact.html
+#
+contact: ${GEN_TOP_HTML} contact.md
+	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
+	@echo "You wish to make contact with the IOCCC Judges?"
+	@${GEN_TOP_HTML} contact
+	@echo
+	@echo "I hope you're used to confused aliens!"
+	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
+
+
 # generate thanks-for-help.html
 #
 # So Long, and Thanks for All the Fish :-)
@@ -657,7 +687,10 @@ gen_next: ${GEN_TOP_HTML} next/README.md next/guidelines.md next/rules.md
 
 markdown: ${GEN_TOP_HTML} markdown.md
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
-	${GEN_TOP_HTML} -v 1 markdown
+	@echo "You want to markdown?"
+	@${GEN_TOP_HTML} markdown
+	@echo
+	@echo "Careful that we don't mark down your submission!"
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
 rules: ${GEN_TOP_HTML} next/rules.md
@@ -672,7 +705,10 @@ guidelines: ${GEN_TOP_HTML} next/guidelines.md
 
 security: ${GEN_TOP_HTML} SECURITY.md
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
-	${GEN_TOP_HTML} -v 1 SECURITY
+	@echo "You wish to make IOCCC entries secure?"
+	@${GEN_TOP_HTML} SECURITY
+	@echo
+	@echo "We also didn't want Pluto demoted!"
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
 

--- a/README.html
+++ b/README.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -452,9 +465,9 @@ from the Bourne Shell source and the <code>finger(1)</code> command as distribut
 If this is what could result from what some people claim is reasonable
 programming practice, then to what depths might quality sink if people really
 tried to write poor code?</p>
-<p>I put that question to the USENET news groups net.lang.c and net.unix-wizards in
-the form of a contest. I selected a form similar to the contest
-(<a href="https://www.bulwer-lytton.com">Bulwer-Lytton</a> contest) that asks people to create the
+<p>I, Landon Curt Noll, put that question to the USENET news groups <code>net.lang.c</code>
+and <code>net.unix-wizards</code> in the form of a contest. I selected a form similar to the
+<a href="https://www.bulwer-lytton.com">Bulwer-Lytton Contest</a> that asks people to create the
 worst opening line to a novel (that contest in turn was inspired by disgust over
 <a href="https://en.wikipedia.org/wiki/Paul_Clifford">a novel</a> by <a href="https://en.wikipedia.org/wiki/Edward_Bulwer-Lytton">Edward
 Bulwer-Lytton</a> that opened

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ If this is what could result from what some people claim is reasonable
 programming practice, then to what depths might quality sink if people really
 tried to write poor code?
 
-I put that question to the USENET news groups net.lang.c and net.unix-wizards in
-the form of a contest.  I selected a form similar to the contest
-([Bulwer-Lytton](https://www.bulwer-lytton.com) contest) that asks people to create the
+I, Landon Curt Noll, put that question to the USENET news groups `net.lang.c`
+and `net.unix-wizards` in the form of a contest.  I selected a form similar to the
+[Bulwer-Lytton Contest](https://www.bulwer-lytton.com) that asks people to create the
 worst opening line to a novel (that contest in turn was inspired by disgust over
 [a novel](https://en.wikipedia.org/wiki/Paul_Clifford) by [Edward
 Bulwer-Lytton](https://en.wikipedia.org/wiki/Edward_Bulwer-Lytton) that opened

--- a/SECURITY.html
+++ b/SECURITY.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/about.html
+++ b/about.html
@@ -6,14 +6,14 @@
 <!-- START: this line starts content from: inc/head.default.html -->
 
 <head>
-<link rel="stylesheet" href="../../ioccc.css">
+<link rel="stylesheet" href="./ioccc.css">
 <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-<title>The International Obfuscated C Code Contest</title>
-<link rel="icon" type="image/x-icon" href="../../favicon.ico">
-<meta name="description" content="FILES.md for 2018/ferguson">
-<meta name="keywords" content="IOCCC, 2018/ferguson, FILES.md">
+<title>About the International Obfuscated C Code Contest</title>
+<link rel="icon" type="image/x-icon" href="./favicon.ico">
+<meta name="description" content="What is the IOCCC?">
+<meta name="keywords" content="IOCCC, International, Obfuscated, C, c, IOCCC, ioccc, obfuscated, Obfuscate, obfuscate, Landon Curt Noll, chongo, Leonid A. Broukhis, leob">
 </head>
 
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
@@ -25,14 +25,14 @@
 <!-- END: this line ends content from: inc/head.default.html -->
 
 <!-- -->
-<!-- This web page was formed via the tool: bin/gen-other-html.sh -->
-<!-- The content of main section of this web page came from: 2018/ferguson/FILES.md -->
+<!-- This web page was formed via the tool: bin/gen-top-html.sh -->
+<!-- The content of main section of this web page came from: about.md -->
 <!-- -->
 
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<!-- !!! Do not modify this web page, instead modify the file: 2018/ferguson/FILES.md !!! -->
-<!-- !!! Do not modify this web page, instead modify the file: 2018/ferguson/FILES.md !!! -->
-<!-- !!! Do not modify this web page, instead modify the file: 2018/ferguson/FILES.md !!! -->
+<!-- !!! Do not modify this web page, instead modify the file: about.md !!! -->
+<!-- !!! Do not modify this web page, instead modify the file: about.md !!! -->
+<!-- !!! Do not modify this web page, instead modify the file: about.md !!! -->
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 
 <!-- Markdown content was converted into HTML via the tool: bin/md2html.sh -->
@@ -48,7 +48,7 @@
   <nav class="topbar">
     <div class="container">
       <div class="logo">
-        <a href="../../index.html" class="logo-link">
+        <a href="./index.html" class="logo-link">
           IOCCC
        </a>
       </div>
@@ -61,43 +61,43 @@
 
           <div class="sub-item">
             <div class="outfit-font">
-              <a href="../../years.html" class="sub-item-link">
+              <a href="./years.html" class="sub-item-link">
                 Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../authors.html" class="sub-item-link">
+              <a href="./authors.html" class="sub-item-link">
                 Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../location.html" class="sub-item-link">
+              <a href="./location.html" class="sub-item-link">
                 Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../bugs.html" class="sub-item-link">
+              <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
                 Fixing entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
+              <a href="./faq.html#fix_author" class="sub-item-link">
                 Updating author info
               </a>
             </div>
 
 	    <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
+              <a href="./thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
               </a>
             </div>
@@ -111,31 +111,31 @@
 
           <div class="sub-item">
             <div class="outfit-font">
-              <a href="../../news.html" class="sub-item-link">
+              <a href="./news.html" class="sub-item-link">
                 News
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../status.html" class="sub-item-link">
+              <a href="./status.html" class="sub-item-link">
                 Contest status
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../next/index.html" class="sub-item-link">
+              <a href="./next/index.html" class="sub-item-link">
                 Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../markdown.html" class="sub-item-link">
+              <a href="./markdown.html" class="sub-item-link">
                 Markdown guidelines
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
+              <a href="./SECURITY.html" class="sub-item-link">
                 Security policy
               </a>
             </div>
@@ -150,31 +150,31 @@
 
           <div class="sub-item">
             <div class="outfit-font">
-              <a href="../../faq.html" class="sub-item-link">
+              <a href="./faq.html" class="sub-item-link">
                   Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
+              <a href="./faq.html#submit" class="sub-item-link">
                 How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#compiling" class="sub-item-link">
+              <a href="./faq.html#compiling" class="sub-item-link">
                 Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#running_entries" class="sub-item-link">
+              <a href="./faq.html#running_entries" class="sub-item-link">
                 Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#help" class="sub-item-link">
+              <a href="./faq.html#help" class="sub-item-link">
                 How to help
               </a>
             </div>
@@ -189,25 +189,25 @@
 
           <div class="sub-item">
             <div class="outfit-font">
-              <a href="../../index.html" class="sub-item-link">
+              <a href="./index.html" class="sub-item-link">
                 Home page
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../about.html" class="sub-item-link">
+              <a href="./about.html" class="sub-item-link">
                 About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../judges.html" class="sub-item-link">
+              <a href="./judges.html" class="sub-item-link">
                 The Judges
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../contact.html" class="sub-item-link">
+              <a href="./contact.html" class="sub-item-link">
                 Contact us
               </a>
             </div>
@@ -219,14 +219,14 @@
 
   <div class="header-mobile-menu">
     <noscript>
-      <a href="../../nojs-menu.html" class="topbar-js-label">
+      <a href="./nojs-menu.html" class="topbar-js-label">
         Please Enable JavaScript
       </a>
     </noscript>
 
     <button id="header-open-menu-button" class="topbar-mobile-menu">
       <img
-        src="../../png/hamburger-icon-open.png"
+        src="./png/hamburger-icon-open.png"
         alt="hamburger style menu icon - open state"
         width=48
         height=48>
@@ -234,7 +234,7 @@
 
     <button id="header-close-menu-button" class="hide-content">
       <img
-        src="../../png/hamburger-icon-closed.png"
+        src="./png/hamburger-icon-closed.png"
         alt="hamburger style menu icon - closed state"
         width=48
         height=48>
@@ -249,31 +249,31 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
-            <a class="mobile-submenu-item" href="../../years.html">
+            <a class="mobile-submenu-item" href="./years.html">
               Winning entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../authors.html">
+            <a class="mobile-submenu-item" href="./authors.html">
               Winning authors
             </a>
 
-            <a class="mobile-submenu-item" href="../../location.html">
+            <a class="mobile-submenu-item" href="./location.html">
               Location of authors
             </a>
 
-            <a class="mobile-submenu-item" href="../../bugs.html">
+            <a class="mobile-submenu-item" href="./bugs.html">
               Bugs and (mis)features
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
               Fixing entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
               Updating author info
             </a>
 
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
               Thanks for the help
             </a>
           </div>
@@ -286,23 +286,23 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
-            <a class="mobile-submenu-item" href="../../news.html">
+            <a class="mobile-submenu-item" href="./news.html">
               News
             </a>
 
-            <a class="mobile-submenu-item" href="../../status.html">
+            <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
-            <a class="mobile-submenu-item" href="../../next/index.html">
+            <a class="mobile-submenu-item" href="./next/index.html">
               Rules and guidelines
             </a>
 
-            <a class="mobile-submenu-item" href="../../markdown.html">
+            <a class="mobile-submenu-item" href="./markdown.html">
               Markdown guidelines
             </a>
 
-            <a class="mobile-submenu-item" href="../../SECURITY.html">
+            <a class="mobile-submenu-item" href="./SECURITY.html">
               Security policy
             </a>
           </div>
@@ -314,23 +314,23 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
-            <a class="mobile-submenu-item" href="../../faq.html">
+            <a class="mobile-submenu-item" href="./faq.html">
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
+            <a class="mobile-submenu-item" href="./faq.html#submit">
               How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
               Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
               Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#help">
+            <a class="mobile-submenu-item" href="./faq.html#help">
               How to help
             </a>
 
@@ -343,19 +343,19 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
-            <a class="mobile-submenu-item" href="../../index.html">
+            <a class="mobile-submenu-item" href="./index.html">
               Home page
             </a>
 
-            <a class="mobile-submenu-item" href="../../about.html">
+            <a class="mobile-submenu-item" href="./about.html">
               About the IOCCC
             </a>
 
-            <a class="mobile-submenu-item" href="../../judges.html">
+            <a class="mobile-submenu-item" href="./judges.html">
               The Judges
             </a>
 
-            <a class="mobile-submenu-item" href="../../contact.html">
+            <a class="mobile-submenu-item" href="./contact.html">
               Contact us
             </a>
           </div>
@@ -398,25 +398,24 @@
 <!-- START: this line starts content from: inc/header.default.html -->
 
 <div class="header">
-  <a href="../../2011/zucker/index.html">
-      <img src="../../png/ioccc.png"
+  <a href="./2011/zucker/index.html">
+      <img src="./png/ioccc.png"
 	   alt="IOCCC image by Matt Zucker"
 	   width=300
 	   height=110>
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
-  <h2>FILES.html for 2018/ferguson</h2>
+  <h2>About the IOCCC</h2>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->
-<!-- START: this line starts content from: inc/navbar.up2index.html -->
+<!-- START: this line starts content from: inc/navbar.empty.html -->
 
 <div class="navbar">
-  <a class="Left" href="index.html">&uarr; jump to 2018/ferguson/index.html &uarr;</a>
-  <a class="Right" href="https://validator.w3.org/nu/?doc=https%3A%2F%2Fioccc-src.github.io%2Ftemp-test-ioccc%2F2018%2Fferguson%2FFILES.html">&#x2713;</a>
+<a class="Right" href="https://validator.w3.org/nu/?doc=https%3A%2F%2Fioccc-src.github.io%2Ftemp-test-ioccc%2Fabout.html">&#x2713;</a>
 </div>
 
-<!-- END: this line ends content from: inc/navbar.up2index.html -->
+<!-- END: this line ends content from: inc/navbar.empty.html -->
 <!-- START: this line starts content from: inc/before-content.default.html -->
 
     <div class="content" id="content">
@@ -424,67 +423,50 @@
 <!-- END: this line ends content from: inc/before-content.default.html -->
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
-<!-- BEFORE: 1st line of markdown file: 2018/ferguson/FILES.md -->
-<h1 id="list-of-files-in-this-entry-with-a-brief-description">List of files in this entry with a brief description</h1>
+<!-- BEFORE: 1st line of markdown file: about.md -->
+<h1 id="about-the-international-obfuscated-c-code-contest-ioccc">About the International Obfuscated C Code Contest (IOCCC)</h1>
+<p>The IOCCC stands for the International Obfuscated C Code Contest.
+The IOCCC is a C programming contest.</p>
+<p>The goals of the IOCCC are:</p>
 <ul>
-<li><a href="prog.c">prog.c</a>
-<ul>
-<li>This is the source file to the <code>weasel</code> program.</li>
-</ul></li>
-<li><a href="prog.alt.c">prog.alt.c</a>
-<ul>
-<li>This is the source code file to the <code>weasel.alt</code> program.</li>
-</ul></li>
-<li><a href="test.sh">test.sh</a>
-<ul>
-<li>Script provided to test the weasel program.</li>
-</ul></li>
-<li><a href="test-strings.txt">test-strings.txt</a>
-<ul>
-<li>The <code>test.sh</code> script reads from this file and runs the program with these
-target strings.</li>
-</ul></li>
-<li><a href="Makefile">Makefile</a>
-<ul>
-<li>The Makefile that simplifies compilation as well as providing some deep
-magic and other things designed by the IOCCC judges. There’s also a <code>make   test</code> target that runs the <code>test.sh</code> script. The index.html file shows how
-to pass options to the script itself.</li>
-</ul></li>
-<li><a href="weasel.1">weasel.1</a>
-<ul>
-<li>The man page for weasel.</li>
-</ul></li>
-<li><a href="rpm.html">rpm.html</a>
-<ul>
-<li>This file briefly answers ‘why’ I submitted an rpm spec file.</li>
-</ul></li>
-<li><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/ferguson/weasel.spec">weasel.spec</a>
-<ul>
-<li>The RPM spec file for building the RPM. This is specific to the entry on
-the IOCCC website but would also be available in the source rpm file if it
-was built.</li>
-</ul></li>
-<li><a href="FILES.html">FILES.html</a>
-<ul>
-<li>This web page.</li>
-</ul></li>
+<li>To write the most Obscure/Obfuscated C program within the rules.</li>
+<li>To show the importance of programming style, in an ironic way.</li>
+<li>To stress C compilers with unusual code.</li>
+<li>To illustrate some of the subtleties of the C language.</li>
+<li>To provide a safe forum for poor C code. :-)</li>
+<li>To have fun with C!</li>
 </ul>
-<hr style="width:10%;text-align:left;margin-left:0">
-<p>Jump to: <a href="#">top</a></p>
-<!--
-
-    Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.
-
-    You are free to share and adapt this file under the terms of this license:
-
-        Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
-
-    For more information, see:
-
-        https://creativecommons.org/licenses/by-sa/4.0/
-
--->
-<!-- AFTER: last line of markdown file: 2018/ferguson/FILES.md -->
+<p>See the
+FAQ on “<a href="faq.html#ioccc_start">start of the IOCCC</a>”
+and the
+FAQ on “<a href="faq.html#website_history">history of the IOCCC website</a>”
+for more information the background of the IOCCC.</p>
+<p>See the
+FAQ on “<a href="faq.html#submit">entering the IOCCC</a>”
+for information on how to enter and submit to the IOCCC.</p>
+<p>If you are still confused, consider the nature of
+the <a href="next/rules.html">IOCCC Rules</a> and of the <a href="next/guidelines.html">IOCCC
+Guidelines</a>. You will see a dose of the technical,
+mixed with “nerd humor” (or humour if you prefer 🤓).</p>
+<p>If after all that you are still confused, sorry (tm Canada 😉).
+Consider this: While the IOCCC often attempts to be presentable,
+it is under no obligation to be wholly understandable. One might
+say that to truly understand the IOCCC is problematic. And if
+someone did manage to fully understand the IOCCC, then perhaps
+this <strong>modified</strong> quote from the <a href="https://en.wikipedia.org/wiki/The_Hitchhiker&#39;s_Guide_to_the_Galaxy">The Hitchhiker’s Guide to the
+Galaxy</a>
+may apply:</p>
+<blockquote>
+<p>“There is a theory which states that if ever anyone discovers
+exactly what the IOCCC is for and why it is here, it will
+instantly disappear and be replaced by something even more bizarre
+and inexplicable.</p>
+<p>There is another theory which states that this has
+<a href="faq.html#great_fork_merge">already happened</a>.” 😜</p>
+</blockquote>
+<p>Share and enjoy! ☺️</p>
+<p>Jump to: <a href="#">top</a>
+<!-- AFTER: last line of markdown file: about.md --></p>
 
 <!-- END: this line ends content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 <!-- START: this line starts content from: inc/after-content.default.html -->
@@ -521,13 +503,13 @@ was built.</li>
 	     rel="license noopener noreferrer"
 	     style="display:inline-block;">CC BY-SA 4.0</a></b>.
 	  <img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;"
-	       src="../../png/cc.png"
+	       src="./png/cc.png"
 	       alt="cc inside circle symbol">
 	  <img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;"
-	       src="../../png/by.png"
+	       src="./png/by.png"
 	       alt="person inside circle symbol">
 	  <img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;"
-	       src="../../png/sa.png"
+	       src="./png/sa.png"
 	       alt="arrow looping back on itself inside circle symbol"><br>
 	You should <b>carefully review</b> the
 	    <b><a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode.en"
@@ -535,7 +517,7 @@ was built.</li>
 		rel="license noopener noreferrer">CC BY-SA 4.0 LEGAL CODE</a></b>
 	    before using the licensed material.<br>
 	You may wish to review the
-	    <b><a href="../../license.html"
+	    <b><a href="./license.html"
 		target="_blank"
 		rel="license noopener noreferrer">highlights of some of the key features and terms</a></b>
 	    of <b>CC BY-SA 4.0</b>.<br>
@@ -544,7 +526,7 @@ was built.</li>
 
     <div id="coda"><h3>Coda</h3>
 	<p>
-	<a href="https://validator.w3.org/nu/?doc=https%3A%2F%2Fioccc-src.github.io%2Ftemp-test-ioccc%2F2018%2Fferguson%2FFILES.html" rel="nofollow">Nu HTML check this web page</a><br>
+	<a href="https://validator.w3.org/nu/?doc=https%3A%2F%2Fioccc-src.github.io%2Ftemp-test-ioccc%2Fabout.html" rel="nofollow">Nu HTML check this web page</a><br>
 	<a href="#top">Jump to top</a> <a href="#content">Jump to Content</a>
 	</p>
     </div>

--- a/about.html
+++ b/about.html
@@ -448,7 +448,7 @@ for information on how to enter and submit to the IOCCC.</p>
 the <a href="next/rules.html">IOCCC Rules</a> and of the <a href="next/guidelines.html">IOCCC
 Guidelines</a>. You will see a dose of the technical,
 mixed with “nerd humor” (or humour if you prefer 🤓).</p>
-<p>If after all that you are still confused, sorry (tm Canada 😉).
+<p>If after all that you are still confused, sorry (tm Canada 🇨😉).
 Consider this: While the IOCCC often attempts to be presentable,
 it is under no obligation to be wholly understandable. One might
 say that to truly understand the IOCCC is problematic. And if

--- a/about.html
+++ b/about.html
@@ -448,7 +448,7 @@ for information on how to enter and submit to the IOCCC.</p>
 the <a href="next/rules.html">IOCCC Rules</a> and of the <a href="next/guidelines.html">IOCCC
 Guidelines</a>. You will see a dose of the technical,
 mixed with “nerd humor” (or humour if you prefer 🤓).</p>
-<p>If after all that you are still confused, sorry (tm Canada 🇨😉).
+<p>If after all that you are still confused, sorry tm Canada 🇨🇦😉).
 Consider this: While the IOCCC often attempts to be presentable,
 it is under no obligation to be wholly understandable. One might
 say that to truly understand the IOCCC is problematic. And if

--- a/about.html
+++ b/about.html
@@ -448,7 +448,7 @@ for information on how to enter and submit to the IOCCC.</p>
 the <a href="next/rules.html">IOCCC Rules</a> and of the <a href="next/guidelines.html">IOCCC
 Guidelines</a>. You will see a dose of the technical,
 mixed with “nerd humor” (or humour if you prefer 🤓).</p>
-<p>If after all that you are still confused, sorry tm Canada 🇨🇦😉).
+<p>If after all that you are still confused, sorry (tm Canada 🇨🇦😉).
 Consider this: While the IOCCC often attempts to be presentable,
 it is under no obligation to be wholly understandable. One might
 say that to truly understand the IOCCC is problematic. And if

--- a/about.md
+++ b/about.md
@@ -27,7 +27,7 @@ the [IOCCC Rules](next/rules.html) and of the [IOCCC
 Guidelines](next/guidelines.html).  You will see a dose of the technical,
 mixed with "nerd humor" (or humour if you prefer 🤓).
 
-If after all that you are still confused, sorry (tm Canada 🇨😉).
+If after all that you are still confused, sorry tm Canada 🇨🇦😉).
 Consider this: While the IOCCC often attempts to be presentable,
 it is under no obligation to be wholly understandable.  One might
 say that to truly understand the IOCCC is problematic. And if

--- a/about.md
+++ b/about.md
@@ -27,7 +27,7 @@ the [IOCCC Rules](next/rules.html) and of the [IOCCC
 Guidelines](next/guidelines.html).  You will see a dose of the technical,
 mixed with "nerd humor" (or humour if you prefer 🤓).
 
-If after all that you are still confused, sorry tm Canada 🇨🇦😉).
+If after all that you are still confused, sorry (tm Canada 🇨🇦😉).
 Consider this: While the IOCCC often attempts to be presentable,
 it is under no obligation to be wholly understandable.  One might
 say that to truly understand the IOCCC is problematic. And if

--- a/about.md
+++ b/about.md
@@ -27,7 +27,7 @@ the [IOCCC Rules](next/rules.html) and of the [IOCCC
 Guidelines](next/guidelines.html).  You will see a dose of the technical,
 mixed with "nerd humor" (or humour if you prefer 🤓).
 
-If after all that you are still confused, sorry (tm Canada 😉).
+If after all that you are still confused, sorry (tm Canada 🇨😉).
 Consider this: While the IOCCC often attempts to be presentable,
 it is under no obligation to be wholly understandable.  One might
 say that to truly understand the IOCCC is problematic. And if

--- a/about.md
+++ b/about.md
@@ -1,0 +1,49 @@
+# About the International Obfuscated C Code Contest (IOCCC)
+
+The IOCCC stands for the International Obfuscated C Code Contest.
+The IOCCC is a C programming contest.
+
+The goals of the IOCCC are:
+
+* To write the most Obscure/Obfuscated C program within the rules.
+* To show the importance of programming style, in an ironic way.
+* To stress C compilers with unusual code.
+* To illustrate some of the subtleties of the C language.
+* To provide a safe forum for poor C code. :-)
+* To have fun with C!
+
+See the
+FAQ on "[start of the IOCCC](faq.html#ioccc_start)"
+and the
+FAQ on "[history of the IOCCC website](faq.html#website_history)"
+for more information the background of the IOCCC.
+
+See the
+FAQ on "[entering the IOCCC](faq.html#submit)"
+for information on how to enter and submit to the IOCCC.
+
+If you are still confused, consider the nature of
+the [IOCCC Rules](next/rules.html) and of the [IOCCC
+Guidelines](next/guidelines.html).  You will see a dose of the technical,
+mixed with "nerd humor" (or humour if you prefer 🤓).
+
+If after all that you are still confused, sorry (tm Canada 😉).
+Consider this: While the IOCCC often attempts to be presentable,
+it is under no obligation to be wholly understandable.  One might
+say that to truly understand the IOCCC is problematic. And if
+someone did manage to fully understand the IOCCC, then perhaps
+this **modified** quote from the [The Hitchhiker's Guide to the
+Galaxy](https://en.wikipedia.org/wiki/The_Hitchhiker's_Guide_to_the_Galaxy)
+may apply:
+
+> "There is a theory which states that if ever anyone discovers
+exactly what the IOCCC is for and why it is here, it will
+instantly disappear and be replaced by something even more bizarre
+and inexplicable.
+>
+> There is another theory which states that this has
+[already happened](faq.html#great_fork_merge)." 😜
+
+Share and enjoy! ☺️
+
+Jump to: [top](#)

--- a/archive/historic/index.html
+++ b/archive/historic/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/author/index.html
+++ b/author/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/authors.html
+++ b/authors.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/bin/chk-entry.sh
+++ b/bin/chk-entry.sh
@@ -2,9 +2,19 @@
 #
 # chk-entry.sh - check if the files in an entry match the entry's manifest
 #
-# Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
+# This script was written in 2024 by:
 #
-# ... with a slight improvement by Cody Boone Ferguson.
+#   chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# with improvements by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
@@ -23,8 +33,6 @@
 # USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 # OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
-#
-# chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
 #
 # Share and enjoy! :-)
 

--- a/bin/find-invalid-json.sh
+++ b/bin/find-invalid-json.sh
@@ -2,17 +2,17 @@
 #
 # find-invalid-json.sh - find invalid JSON files
 #
-# The JSON parser jparse was co-developed in 2022 by:
+# This script was written in 2024 by Cody Boone Ferguson.
+#
+#   "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# The JSON parser and its respective tools were co-developed in 2022 by:
 # 
 #	@xexyl
 #	https://xexyl.net		Cody Boone Ferguson
 #	https://ioccc.xexyl.net
 # and:
 #	chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
-#
-# This script was written in 2024 by Cody Boone Ferguson.
-#
-#   "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # "Share and Enjoy!"
 #     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)

--- a/bin/format-headers.sh
+++ b/bin/format-headers.sh
@@ -15,10 +15,11 @@
 # acting on all README.md files, it only acts on README.md files under git
 # control.
 #
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
 # The Perl code makes sure that for certain headers in the README.md files,
 # there are the correct number of blank lines before/after.
 #
-#   "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Share and enjoy! :-)
 

--- a/bin/gen-authors.sh
+++ b/bin/gen-authors.sh
@@ -2,9 +2,19 @@
 #
 # gen-authors.sh - create the top level authors.html page
 #
-# Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
+# This script was written in 2024 by:
 #
-# .. with very minor improvements in June 2024 by Cody Boone Ferguson.
+#   chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# with improvements by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,

--- a/bin/gen-sitemap.sh
+++ b/bin/gen-sitemap.sh
@@ -2,11 +2,17 @@
 #
 # gen-sitemap.sh - generate an xml sitemap
 #
-# This script was improved by Cody Boone Ferguson / @xexyl to use git ls-files
-# so that other files that might exist in the directories we search are not
-# added to the sitemap.
+# This script was written in 2024 by:
 #
-#   "Because sometimes even IOCCC Judges need some help." :-)
+#   chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# with improvements by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #

--- a/bin/gen-top-html.sh
+++ b/bin/gen-top-html.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env bash
 #
-# gen-top-html.sh - generate all or select top level HTML files from markdown files
+# gen-top-html.sh - generate all or select top level HTML files from markdown
+# files
 #
 # We also generate the bin/index.html file from the bin/README.md file.
+#
 # We also generate the inc/index.html file from the inc/README.md file.
-# We also generate the archive/historic/index.html file from the archive/historic/README.md file.
+#
+# We also generate the archive/historic/index.html file from the
+# archive/historic/README.md file.
+#
+# This script was written in 2024 by:
+#
+#   chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# with improvements by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
 #
 # Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
-#
-# Cody Boone Ferguson made an improvement where one can specify the select top
-# html files to generate to save time. Works just like the script without args
-# but if any args are specified and the markdown file exists it will just
-# generate that or those html files. This is to save time for some Makefile
-# rules that only need update one file.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,
@@ -121,6 +131,7 @@ export SITE_URL="https://ioccc-src.github.io/temp-test-ioccc"
 #
 unset TOP_MD_SET
 declare -ag TOP_MD_SET
+TOP_MD_SET+=("about")
 TOP_MD_SET+=("CODE_OF_CONDUCT")
 TOP_MD_SET+=("README")
 TOP_MD_SET+=("author/README")

--- a/bin/index.html
+++ b/bin/index.html
@@ -62,13 +62,13 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
@@ -80,9 +80,22 @@
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
-                Bugs and (Mis)features
+                Bugs and (mis)features
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
 	    <div class="outfit-font">
               <a href="../thanks-for-help.html" class="sub-item-link">
                 Thanks for the help
@@ -99,31 +112,31 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../status.html" class="sub-item-link">
-                Contest Status
+                Contest status
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
+                Security policy
               </a>
             </div>
 
@@ -144,27 +157,28 @@
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -176,7 +190,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
               </a>
             </div>
 
@@ -188,13 +202,13 @@
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the Judges
+                Contact us
               </a>
             </div>
           </div>
@@ -236,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Winning Authors
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -248,7 +262,15 @@
             </a>
 
             <a class="mobile-submenu-item" href="../bugs.html">
-              Bugs and (Mis)features
+              Bugs and (mis)features
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
             </a>
 
             <a class="mobile-submenu-item" href="../thanks-for-help.html">
@@ -265,23 +287,23 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              News
             </a>
 
             <a class="mobile-submenu-item" href="../status.html">
-              Contest Status
+              Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../SECURITY.html">
-              IOCCC Security Policy
+              Security policy
             </a>
           </div>
         </div>
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Updating author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,7 +344,7 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
             </a>
 
             <a class="mobile-submenu-item" href="../about.html">
@@ -330,11 +352,11 @@
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
+              Contact us
             </a>
           </div>
         </div>

--- a/bin/index.html
+++ b/bin/index.html
@@ -74,13 +74,18 @@
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
-                Bugs and (mis)features
+                Bugs and (Mis)features
+              </a>
+            </div>
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -100,7 +105,7 @@
 
             <div class="outfit-font">
               <a href="../status.html" class="sub-item-link">
-                Contest status
+                Contest Status
               </a>
             </div>
 
@@ -115,6 +120,13 @@
                 IOCCC Markdown Guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                IOCCC Security Policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,7 +138,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
@@ -169,6 +181,12 @@
             </div>
 
             <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
+              </a>
+            </div>
+
+            <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
                 The IOCCC Judges
               </a>
@@ -176,31 +194,7 @@
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contacting the Judges
               </a>
             </div>
           </div>
@@ -246,7 +240,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning Authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -254,9 +248,12 @@
             </a>
 
             <a class="mobile-submenu-item" href="../bugs.html">
-              Bugs and (mis)features
+              Bugs and (Mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +264,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              IOCCC News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
-              Contest status
+              Contest Status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
               Rules and Guidelines
             </a>
 
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
-            </a>
-
             <a class="mobile-submenu-item" href="../markdown.html">
               IOCCC Markdown Guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              IOCCC Security Policy
+            </a>
           </div>
         </div>
 
@@ -309,7 +309,7 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+              Updating author info
             </a>
 
           </div>
@@ -325,6 +325,10 @@
               IOCCC Home
             </a>
 
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
+            </a>
+
             <a class="mobile-submenu-item" href="../judges.html">
               The IOCCC Judges
             </a>
@@ -332,21 +336,8 @@
             <a class="mobile-submenu-item" href="../contact.html">
               Contacting the IOCCC
             </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
-            </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/bin/md2html.cfg
+++ b/bin/md2html.cfg
@@ -67,6 +67,22 @@
 
 # Top level markdown files have no top navigation bar
 
+about.md
+	-H
+	navbar=empty
+	-o
+	bin/subst.default.sh
+	-s
+	TITLE=About the International Obfuscated C Code Contest
+	-s
+	DESCRIPTION=What is the IOCCC?
+	-s
+	KEYWORDS=IOCCC, International, Obfuscated, C, c, IOCCC, ioccc, obfuscated, Obfuscate, obfuscate, Landon Curt Noll, chongo, Leonid A. Broukhis, leob
+	-s
+	HEADER_2=About the IOCCC
+	-D
+	./
+
 CODE_OF_CONDUCT.md
 	-H
 	navbar=empty

--- a/bin/output-year-index.sh
+++ b/bin/output-year-index.sh
@@ -27,9 +27,19 @@
 #
 #	make gen_year_index
 #
-# Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
+# This script was written in 2024 by:
 #
-# .. with very minor improvements in June 2024 by Cody Boone Ferguson.
+#   chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# with improvements by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,

--- a/bin/status2html.sh
+++ b/bin/status2html.sh
@@ -18,9 +18,19 @@
 #
 #	make gen_status
 #
-# Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
+# This script was written in 2024 by:
 #
-# ... with minor improvements made in June 2024 by Cody Boone Ferguson.
+#   chongo (Landon Curt Noll, http://www.isthe.com/chongo/index.html) /\oo/\
+#
+# with improvements by:
+#
+#	@xexyl
+#	https://xexyl.net		Cody Boone Ferguson
+#	https://ioccc.xexyl.net
+#
+# "Because sometimes even the IOCCC Judges need some help." :-)
+#
+# Copyright (c) 2024 by Landon Curt Noll.  All Rights Reserved.
 #
 # Permission to use, copy, modify, and distribute this software and
 # its documentation for any purpose and without fee is hereby granted,

--- a/bugs.html
+++ b/bugs.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -425,6 +438,7 @@ below and you wish to help with a year, you can use these links:</p>
 <li><a href="#2012">2012 entries</a> | <a href="#2013">2013 entries</a> | <a href="#2014">2014 entries</a> | <a href="#2015">2015 entries</a></li>
 <li><a href="#2018">2018 entries</a> | <a href="#2019">2019 entries</a> | <a href="#2020">2020 entries</a></li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="please-read-the-next-sections-if-you-wish-to-help">PLEASE read the next sections if you wish to help</h2>
 <p>There are a number of known problems with IOCCC entries: many of
 which have to do with differences between today’s compiler environments
@@ -447,6 +461,7 @@ website if you have one, should you wish).</p>
 Otherwise if you wish to not worry about it we can do that to make sure the
 format is consistent and clean.</p>
 <p>THANK YOU!</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="to-the-winning-authors">To the winning authors:</h2>
 <p>If you’re the author of an entry that has been fixed and you find it against
 your liking <strong>PLEASE</strong> let us know and we’ll be happy to undo any fixes even if
@@ -459,6 +474,7 @@ that should not have been. Also the definition of <code>INABIAF</code> was chang
 of times. At one point some things were changed to a bug (a usability problem
 for example) to be fixed but when looking at the index.html file it was noticed
 it was documented so the fixes were undone at that point.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="on-all-fixes-improvements-changes">ON <strong>ALL</strong> FIXES / IMPROVEMENTS / CHANGES</h3>
 <p>Make <strong>ABSOLUTE CERTAIN</strong> that you test the entry <em>BEFORE</em> <strong>AND</strong> <em>AFTER</em> your
 changes! This includes output and the same input functionality! Sometimes it
@@ -481,6 +497,7 @@ would be wise to test it under all that you have access to. Otherwise we can do
 that. Of course if the entry does not work under any platform and you fix it for
 one that’s more than fine (and it has been done numerous times).</p>
 <p>Again, THANK YOU!</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr>
 <h1 id="list-of-statuses">LIST OF STATUSES</h1>
 <h2 id="please-read-before-fixing">PLEASE READ BEFORE FIXING</h2>
@@ -488,7 +505,9 @@ one that’s more than fine (and it has been done numerous times).</p>
 <p>Entries below have one or more of the following <em><strong>STATUS</strong></em> values. Please see
 the text below for more information. If an entry has more than one status it
 means that either they all apply or they complement each other.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="general-notes-about-the-statuses-and-making-fixes">General notes about the statuses and making fixes</h2>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="compiler-warnings-are-very-rarely-a-problem">Compiler warnings are very rarely a problem</h3>
 <p>In general warnings should NOT be addressed. The only time they should be
 CONSIDERED is when the entry does not work. However note that sometimes trying
@@ -518,18 +537,22 @@ was a bit more involved but with <code>1985/applin</code> one need only add to t
 <code>-include unistd.h</code>. So there are some cases where fixing warnings can fix a
 problem but in general they should be ignored even if they’re annoying.</p>
 <p>Hopefully with the example entries listed above you get the idea.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="general-request-on-original-code">General request on original code:</h3>
 <p>If you’re fixing an entry please make as <em>FEW CHANGES AS POSSIBLE</em>! This is to
 make it as close to the original but allowing it to work. This might be less of
 a problem when providing alternate versions but it might still be nice to have
 it as close as possible to the original. See also below two points.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="request-for-one-liners">Request for one-liners:</h3>
-<p>For one-liners <em>PLEASE KEEP THE FILE ONE LINE IF AT ALL POSSIBLE</em>! If it needs an
+<p>For one-liners <em>PLEASE KEEP THE FILE ONE LINE IF AT ALL POSSIBLE</em>! See the
+<a href="next/guidelines.html">guidelines</a> for what constitutes a one-liner. If it needs an
 include you can update the Makefile <code>CINCLUDE</code> variable. For instance if it
 needs <code>stdio.h</code> you could do <code>-include stdio.h</code>. Please leave a space after the
 <code>=</code> in the Makefile. You may also have extra long lines if this seems useful to
 make it a one-liner even if it kind of makes it longer than what the judges
 consider a one-liner, at least within reason. Thank you!</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="on-layout-of-program-source">On layout of program source:</h3>
 <p>If you make changes <em>PLEASE TRY AND KEEP THE SOURCE CODE LAYOUT AS CLOSE TO THE
 ORIGINAL AS POSSIBLE</em>. This might not always be possible and if you have an
@@ -538,6 +561,7 @@ break code! Some have experienced this many times with vim so he tends to
 disable all format options when formatting code. In vim you should be able to do
 that with:</p>
 <pre><code>    :set formatoptions=</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-known-bug">STATUS: known bug</h2>
 <p><strong>Please help us fix</strong>!</p>
 <p>Entries with this status have one or more bugs that need to be fixed. Are you
@@ -546,28 +570,35 @@ able to fix it? We welcome your help!</p>
 where it might sometimes border on tampering with the program. And after all,
 these are not meant to be maintainable or even good programming style! Use
 careful judgement when fixing bugs please!</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-possible-bug">STATUS: possible bug</h2>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="system-dependent-bug-possibly">System dependent bug possibly</h3>
 <p><strong>Please help test, and if necessary fix this bug</strong>!</p>
 <p>Entries with this status might or might not have a bug possibly depending on the
 system. In these entries it’s unknown if there is a bug and sometimes it’s
 because we do not remember and sometimes we don’t have the appropriate system or
 environment to test and fix any possible problems.</p>
-<h2 id="status-might-not-be-completely-functional">STATUS: might not be completely functional</h2>
+<p>Jump to: <a href="#">top</a></p>
+<h3 id="status-might-not-be-completely-functional">STATUS: might not be completely functional</h3>
 <p><strong>Can you confirm there is a bug?</strong></p>
 <p>Although these entries <em>appear</em> to work for one or more reasons we’re unsure if
 they are completely functional. Can you confirm this? Please let us know so we
 can fix it!</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-probable-bug">STATUS: probable bug</h2>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="possible-system-dependent-bug">Possible system dependent bug</h3>
 <p><strong>Please help test and if necessary fix this bug</strong>!</p>
 <p>Entries with this status almost certainly have a bug or some other problem. The
 issue or issues might depend on the system much like the above <em>STATUS: possible
 bug (possibly depending on system)</em>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-doesnt-work-with-some-platforms">STATUS: doesn’t work with some platforms</h2>
 <p><strong>Please help us fix this bug</strong>!</p>
 <p>Entries with this status do not work under some OSes and/or architectures (and/or
 something else?). Please help us to fix it!</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-doesnt-work-with-some-compilers">STATUS: doesn’t work with some compilers</h2>
 <p><strong>Please provide alternative code or fix for more compilers</strong>!</p>
 <p>Some entries do not work with some compilers. A good example is
@@ -578,6 +609,7 @@ tampering this is okay though it’s probably not possible with the above
 mentioned entry; otherwise it would be better to provide alternate code. In some
 cases it might be better to provide alternate code anyway. Use a judgement call
 here as best you can manage.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-main-function-args-not-allowed">STATUS: main() function args not allowed</h2>
 <p><strong>Please help us fix the main() function</strong>!</p>
 <p><strong>NOTE</strong>: it appears that most if not all of these have been fixed except perhaps
@@ -601,9 +633,8 @@ entries the fix was done with a new function, often called <code>pain()</code> :
 <p><strong>NOTE for macOS users</strong>: please be aware that <em>gcc</em> under macOS <strong>is actually
 clang</strong> despite the fact it might appear to be gcc: no symlink and both gcc and
 clang exist but the gcc is clang which you’ll see if you run <code>gcc --version</code>.</p>
-<p>A tip and some fix methods from <a href="authors.html#Cody_Boone_Ferguson">Cody Boone
-Ferguson</a>: in the older days args to main()
-not given a type were implicit ints but when they’re required to be <code>char **</code>
+<p>A tip and some fix methods: in the older days args to <code>main()</code>
+not given a type were implicit <code>int</code>s but when they’re required to be <code>char **</code>
 this can cause a problem. In some cases it was possible to use a <code>char *</code> inside
 <code>main()</code> (see <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/tromp/tromp.c">1989/tromp/tromp.c</a> and
 <a href="1986/holloway/index.html">1986/holloway/holloway.c</a> for two examples though
@@ -612,6 +643,7 @@ pointers to be used like an int and other times a cast was necessary. There are
 various techniques to get these to compile. In some cases this introduced a
 problem but typically if not always that problem exists with compilers that are
 less strict.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-main-has-only-one-arg">STATUS: main() has only one arg</h2>
 <p><strong>Please help modify so that main() as 2 or 3 args</strong>!</p>
 <p>Because some versions of clang complain about the number of args of <code>main()</code> and
@@ -622,6 +654,7 @@ impossible especially as it already claims having only one arg is not allowed.
 At this time (04 Feb 2024) there is one entry known (it is possible that not all
 were checked) that has this problem but it’s not as simple as the others to fix
 without breaking it.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-compiled-executable-crashes">STATUS: compiled executable crashes</h2>
 <p><strong>Please help us fix this bug</strong>!</p>
 <p>While such entries can compile, the resulting executable sometimes or always
@@ -630,6 +663,7 @@ crashes.</p>
 not mutually exclusive in some cases).</p>
 <p>REMINDER: if you’re debugging a crash it will be very helpful to have <code>-O0 -g</code>
 or if you can <code>-ggdb3</code> when compiling as that will help with debugging symbols.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-uses-gets">STATUS: uses gets()</h2>
 <p><strong>Please help us change use of gets() to fgets()</strong>, if possible.</p>
 <p>Entries with this status use <code>gets()</code> which is unsafe because it has no limit on
@@ -667,12 +701,14 @@ during compiling, linking and/or runtime, sometimes causing confusing output (as
 noted above).</p>
 <p>Sometimes <code>getline(3)</code> will work but note that this function also stores the
 newline just like <code>fgets(3)</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-missing-files">STATUS: missing file(s)</h2>
 <p><strong>Please help is by finding missing file(s)</strong>!</p>
 <p>In these entries one file or multiple files are missing from the repo. In some
 cases these files can be found on the <a href="https://www.ioccc.org">IOCCC website</a> but
 in other cases they are entirely absent. In this case you’ll probably have to
 contact the author (unless you are the author! :-) ).</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-missing-or-dead-link">STATUS: missing or dead link</h2>
 <p><strong>Please help is fix missing or dead link(s)</strong>!</p>
 <p>This is as they sound: a link is either missing or it’s no longer valid. In many
@@ -680,6 +716,7 @@ cases the <a href="https://web.archive.org">Internet Wayback Machine</a> will be
 useful but there happens to be numerous links that this is not helpful. In other
 cases the URL has changed. Some of these have been discovered by the Internet
 Wayback Machine with the orange status.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="statuses-of-internet-wayback-machine-archive">Statuses of Internet Wayback Machine archive:</h3>
 <ul>
 <li>Green (3xx): redirect (this has been used to find changes in URL).</li>
@@ -687,6 +724,7 @@ Wayback Machine with the orange status.</p>
 <li>Blue: this is a good link (but note that this doesn’t mean that it’s correct!).</li>
 </ul>
 <p>The archive website will tell you if the link was never captured.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="status-inabiaf---please-do-not-fix">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h2>
 <h3 id="inabiaf-its-not-a-bug-its-a-feature--">INABIAF: It’s not a bug it’s a feature :-)</h3>
 <p>Entries with this status should NOT be touched (unless they have another status
@@ -710,17 +748,16 @@ known to segfault but are considered features.</p>
 says it can be fixed it can be. Otherwise it should not be.</p>
 <p>Nonetheless we challenge you to fix these entries for educational/instructional
 value and/or enjoyment but we kindly request that you <strong>DO NOT</strong> submit a pull
-request unless it’s a bug or (mis)feature we would like you to fix! If you can’t
-figure it out you’re invited to look at the git diffs, where there are some
-(some were fixed earlier on but rolled back as both Cody and Landon individually
-felt that the fix was tampering with the entry).</p>
+request unless it’s a bug or (mis)feature we would like you to fix!</p>
 <p><strong>NOTE</strong>: in the case of <code>gets()</code> we’ve fixed some to avoid the warning of the
 compiler, linker or even during runtime, depending on the system. In <a href="1990/tbr/index.html">some cases
 like 1990/tbr</a> the fix actually prevents confusing output (though that
 was not the only fix made in that entry).</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="exception-your-own-entries">Exception: your own entries</h3>
 <p>Of course if you’re the author you’re welcome to fix your own entry, prefer your
 own fix or suggest that they’re fixed!</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr>
 <h1 id="list-of-entries-by-year-sorted-in-alphabetical-order-per-year">List of entries by year, sorted in alphabetical order per year</h1>
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -728,9 +765,11 @@ own fix or suggest that they’re fixed!</p>
 <h1 id="section">1984</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1984_decot">
 <h2 id="decot">1984/decot</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-1">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1984decotdecot.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/decot/decot.c">1984/decot/decot.c</a></h3>
 <h3 id="information-1984decotindex.html">Information: <a href="1984/decot/index.html">1984/decot/index.html</a></h3>
@@ -740,16 +779,20 @@ code. In particular you should see something like:</p>
     &#39;&quot;,x);      /*
     \</code></pre>
 <p>without a newline after the <code>\</code>. This is not a bug.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1984_laman">
 <h2 id="laman">1984/laman</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-2">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1984lamanlaman.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/laman/laman.c">1984/laman/laman.c</a></h3>
 <h3 id="information-1984lamanindex.html">Information: <a href="1984/laman/index.html">1984/laman/index.html</a></h3>
 <p>This program will very likely crash or do something funny without an arg.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1984_mullender">
 <h2 id="mullender">1984/mullender</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-3">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1984mullendermullender.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1984/mullender/mullender.c">1984/mullender/mullender.c</a></h3>
 <h3 id="information-1984mullenderindex.html">Information: <a href="1984/mullender/index.html">1984/mullender/index.html</a></h3>
@@ -764,53 +807,64 @@ least as best as can be determined: running the code on the binary itself does
 produce a <code>short[]</code> that can compile in modern systems but it will not work.
 Before the fix it would fail in some cases and it is possible that in some cases
 it might still fail.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1985">
 <h1 id="section-1">1985</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There are no known bugs or (mis)features for entries in 1985.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1986">
 <h1 id="section-2">1986</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1986_august">
 <h2 id="august">1986/august</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-4">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1986augustaugust.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/august/august.c">1986/august/august.c</a></h3>
 <h3 id="information-1986augustindex.html">Information: <a href="1986/august/index.html">1986/august/index.html</a></h3>
 <p>This entry is known to segfault after printing its output. It was documented by
 the judges and shouldn’t be fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1987">
 <h1 id="section-3">1987</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There are no known bugs or (mis)features for entries in 1987.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1988">
 <h1 id="section-4">1988</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1988_dale">
 <h2 id="dale">1988/dale</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-5">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1988daledale.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1988/dale/dale.c">1988/dale/dale.c</a></h3>
 <h3 id="information-1988daleindex.html">Information: <a href="1988/dale/index.html">1988/dale/index.html</a></h3>
 <p>In linux it might happen that despite no error message or message about doing
 so, the program drops a core file into the directory even though the entry works
 and does not crash.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1989">
 <h1 id="section-5">1989</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_fubar">
 <h2 id="fubar">1989/fubar</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-6">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1989fubarfubar.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/fubar/fubar.c">1989/fubar/fubar.c</a></h3>
 <h3 id="information-1989fubarindex.html">Information: <a href="1989/fubar/index.html">1989/fubar/index.html</a></h3>
@@ -818,9 +872,11 @@ and does not crash.</p>
 details) with a number &lt; 0 or larger than, say 20, it’s very likely that the
 program will turn into an infinite loop trying to compile code and end up with
 with syntax errors. As this was documented it is not a bug to be fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_robison">
 <h2 id="robison">1989/robison</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-7">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1989robisonrobison.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/robison/robison.c">1989/robison/robison.c</a></h3>
 <h3 id="information-1989robisonindex.html">Information: <a href="1989/robison/index.html">1989/robison/index.html</a></h3>
@@ -828,9 +884,11 @@ with syntax errors. As this was documented it is not a bug to be fixed.</p>
 numbers with non-binary digits.</p>
 <p>There are also other cases where this can happen for instance using unsupported
 operators like <code>/</code>. To see what operators are supported check the source code.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1989_westley">
 <h2 id="westley">1989/westley</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-1989westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1989/westley/westley.c">1989/westley/westley.c</a></h3>
 <h3 id="information-1989westleyindex.html">Information: <a href="1989/westley/index.html">1989/westley/index.html</a></h3>
@@ -838,15 +896,22 @@ operators like <code>/</code>. To see what operators are supported check the sou
 it does not. We don’t believe this is because of the fix that lets some versions
 be compiled with clang. An example invocation is:</p>
 <pre><code>    ./ver2 &lt; westley.c</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="a-useful-note-on-changingfixing-this-program">A useful note on changing/fixing this program</h3>
 <p>It should be noted that in additional to rot13 names there is code that is the
-reverse of other code (also wrt names). See the source file and the index.html
-(in the author’s remarks) for more details.</p>
+reverse of other code (also with respect to names). See the source file and the
+index.html (in the author’s remarks) for more details.</p>
 <p>Fixing the (mis)feature is likely to be a very difficult challenge especially
-without breaking something else which is far more likely (see below in tips from
-Cody, who fixed it so the original would compile with <code>clang</code> and at least one
-generated version would compile with <code>clang</code> too, not compromising the other
-versions with <code>gcc</code>). You are welcome to try and fix it if you can!</p>
+without breaking something else which is far more likely (see below tips from).
+You are welcome to try and fix it if you can but unless you can get all to
+compile with <code>clang</code> <strong>AND</strong> <code>gcc</code>, which seems unlikely (see below), this
+should not be touched further. Nonetheless you are welcome to try and fix it if
+you can.</p>
+<p>Be aware, however, that even if you can get it to compile with both <code>gcc</code> and
+<code>clang</code>, different versions will have errors so that it’s not actually a fix.
+For instance it was fixed to work for both <code>clang</code> and <code>gcc</code> but when testing
+the fix in fedora linux it failed to even compile!</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="tips">Tips:</h3>
 <p>The reason this is crashing is that the array <code>irk</code> is being accessed way out of
 bounds by the int <code>gnat</code>. For instance:</p>
@@ -856,6 +921,7 @@ bounds by the int <code>gnat</code>. For instance:</p>
     23  &amp;&amp;gnat!({)Near,noon,/*krelc*/)&lt;0&amp;&amp;(Near= -      irk[-gnat--]-2)))&amp;&amp;main(ABBA,
     (gdb) p gnat
     $1 = -518733305</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="magic-of-the-entry">Magic of the entry:</h3>
 <p>The real trouble is that the code is generated and in a complex way or rather
 ways.</p>
@@ -912,14 +978,17 @@ versions, reversed as well as ROT13 and reversed code, proved much more
 problematic. It is now possible to compile (or maybe mostly compile) all versions with
 clang but on another system and it had syntax errors.</p>
 <p>Enjoy! :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1990">
 <h1 id="section-6">1990</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_baruch">
 <h2 id="baruch">1990/baruch</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-8">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1990baruchbaruch.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/baruch/baruch.c">1990/baruch/baruch.c</a></h3>
 <h3 id="information-1990baruchindex.html">Information: <a href="1990/baruch/index.html">1990/baruch/index.html</a></h3>
@@ -981,10 +1050,12 @@ more time and resources to run as well. For instance:</p>
     18
     12655721857
     ./baruch  37496.97s user 58.50s system 99% cpu 10:27:48.29 total</code></pre>
-<p>This is not considered a bug, however.</p>
+<p>This is a feature, not a bug!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_jaw">
 <h2 id="jaw">1990/jaw</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-1">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-1990jawjaw.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/jaw/jaw.c">1990/jaw/jaw.c</a></h3>
 <h3 id="information-1990jawindex.html">Information: <a href="1990/jaw/index.html">1990/jaw/index.html</a></h3>
@@ -1006,7 +1077,9 @@ sentence.</p>
 <p>If one does, however:</p>
 <pre><code>    echo &quot;Quartz glyph jocks vend, fix, BMW.&quot; | compress | ./btoa | ./jaw | ./jaw</code></pre>
 <p>they will get just</p>
-<pre><code>    oops</code></pre>
+<blockquote>
+<p>oops</p>
+</blockquote>
 <p>which seems to be an error message (one of the fixes was to make it not use
 <code>perror(3)</code> - this fixed something else though it’s no longer known what except
 that in macOS if <code>errno</code> is 0 it reports what looks like an error, rather than
@@ -1016,17 +1089,21 @@ path not having <code>.</code> (this and maybe some other things were fixed) and
 wanting to accept reading from <code>stdin</code> (this in particular) even with the right
 options used, seemingly, it has to write to disk the tarball which seems to
 defeat the purpose. This would ideally be fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_tbr">
 <h2 id="tbr">1990/tbr</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-9">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1990tbrtbr.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/tbr/tbr.c">1990/tbr/tbr.c</a></h3>
 <h3 id="information-1990tbrindex.html">Information: <a href="1990/tbr/index.html">1990/tbr/index.html</a></h3>
 <p>The authors provided a list of features in the
 <a href="1990/tbr/index.html#bugs">BUGS</a> section in their remarks.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_theorem">
 <h2 id="theorem">1990/theorem</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-10">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1990theoremtheorem.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/theorem/theorem.c">1990/theorem/theorem.c</a></h3>
 <h3 id="information-1990theoremindex.html">Information: <a href="1990/theorem/index.html">1990/theorem/index.html</a></h3>
@@ -1035,9 +1112,11 @@ fixed but one thing to note is that if you pass two zeroes to <code>theorem_bkp<
 <code>fibonacci</code> the program will enter an infinite loop, printing 0 over and over
 again; another condition where this occurred was fixed but this one should not
 be fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1990_westley">
 <h2 id="westley-1">1990/westley</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-11">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1990westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1990/westley/westley.c">1990/westley/westley.c</a></h3>
 <h3 id="information-1990westleyindex.html">Information: <a href="1990/westley/index.html">1990/westley/index.html</a></h3>
@@ -1047,14 +1126,17 @@ original. The reason for the &lt; 0 check is it floods the screen (yes this is
 indeed inconsistent with some other entries but it is not worth the time spent,
 maybe, to change it back, especially as it is annoying to have the screen
 flooded).</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1991">
 <h1 id="section-7">1991</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_buzzard">
 <h2 id="buzzard">1991/buzzard</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-12">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1991buzzardbuzzard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/buzzard/buzzard.c">1991/buzzard/buzzard.c</a></h3>
 <h3 id="information-1991buzzardindex.html">Information: <a href="1991/buzzard/index.html">1991/buzzard/index.html</a></h3>
@@ -1062,9 +1144,11 @@ flooded).</p>
 exist or because the default (whatever the source file was at compilation time)
 file does not exist in the directory, this program will very likely crash.</p>
 <p>This is a feature, not a bug.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1991_westley">
 <h2 id="westley-2">1991/westley</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-13">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1991westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1991/westley/westley.c">1991/westley/westley.c</a></h3>
 <h3 id="information-1991westleyindex.html">Information: <a href="1991/westley/index.html">1991/westley/index.html</a></h3>
@@ -1074,14 +1158,17 @@ you’re caught</em>’. :-)</p>
 <p>Please don’t try and fix it as it’s not a bug and was actually documented as a
 possibility. Can you find out how? There’s also a way to make it so that even
 when you’re cheating it ends up winning! Can you figure that out as well?</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1992">
 <h1 id="section-8">1992</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_adrian">
 <h2 id="adrian">1992/adrian</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-14">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992adrianadrian.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/adrian/adrian.c">1992/adrian/adrian.c</a></h3>
 <h3 id="information-1992adrianindex.html">Information: <a href="1992/adrian/index.html">1992/adrian/index.html</a></h3>
@@ -1101,9 +1188,11 @@ read only mode which is another reason) with the <code>%s</code> specifier it wi
 changed either even if it appears to be wrong. Notice too a curious thing: if
 you did change it to <code>fprintf()</code>, even if you have the right number of args, you’d
 have to remove the outer <code>()</code> pair.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_albert">
 <h2 id="albert">1992/albert</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-2">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-1992albertalbert.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/albert/albert.c">1992/albert/albert.c</a></h3>
 <h3 id="information-1992albertindex.html">Information: <a href="1992/albert/index.html">1992/albert/index.html</a></h3>
@@ -1143,9 +1232,11 @@ for the <code>!= 48</code> is also required.</p>
 condition.</p>
 <p>The alt version does fix the problem but it is not obfuscated and not like the
 entry itself. Can you fix the actual entry? You are welcome to try and do so.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_gson">
 <h2 id="gson">1992/gson</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-uses-gets---change-to-fgets-if-possible">STATUS: uses gets() - change to fgets() if possible</h3>
 <h3 id="source-code-1992gsongson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/gson/gson.c">1992/gson/gson.c</a></h3>
 <h3 id="information-1992gsonindex.html">Information: <a href="1992/gson/index.html">1992/gson/index.html</a></h3>
@@ -1157,6 +1248,7 @@ which can be described simply as: first <code>m</code> is set to <code>*++p</cod
 <code>p</code> is argv. Later <code>m</code> is set to point to <code>h</code> which was of size 256. <code>gets(3)</code>
 is called as <code>m = gets(m)</code>) but trying to change it to use <code>fgets(3)</code> breaks the
 program.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-15">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>On the other hand, the author noted the following bugs and limitations:</p>
 <ul>
@@ -1172,19 +1264,22 @@ less.</li>
 </ul>
 <p>… so whether or not the <code>gets(3)</code> should be changed to <code>fgets(3)</code> is up to
 debate.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_kivinen">
 <h2 id="kivinen">1992/kivinen</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-3">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-1992kivinenkivinen.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/kivinen/kivinen.c">1992/kivinen/kivinen.c</a></h3>
 <h3 id="information-1992kivinenindex.html">Information: <a href="1992/kivinen/index.html">1992/kivinen/index.html</a></h3>
 <p>When you start the program everything starts to move over to the right side and
 then ends. <a href="authors.html#Yusuke_Endoh">Yusuke Endoh</a> pointed out that if you
 click the mouse it takes it back towards the centre.</p>
-<p>If you want to try and fix this, you are welcome to try.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_lush">
 <h2 id="lush">1992/lush</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-doesnt-work-with-some-compilers---please-provide-alternative-code-or-fix-for-more-compilers">STATUS: doesn’t work with some compilers - please provide alternative code or fix for more compilers</h3>
 <h3 id="source-code-1992lushlush.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/lush/lush.c">1992/lush/lush.c</a></h3>
 <h3 id="information-1992lushindex.html">Information: <a href="1992/lush/index.html">1992/lush/index.html</a></h3>
@@ -1194,7 +1289,7 @@ properly. Nonetheless it will only work with gcc.</p>
 <p>Unfortunately due to the way the entry works and the fact that other compilers
 like clang have different warnings and errors this simply does not work with
 them.</p>
-<p>Some tips:</p>
+<h4 id="some-tips">Some tips:</h4>
 <p>This entry relies on specific compiler warnings. With gcc it will look something
 like:</p>
 <pre><code>    [...]
@@ -1246,19 +1341,22 @@ than that. For instance this is what it looks like with clang:</p>
 <p>As you might see the part under the <code>warning:</code> line is different.</p>
 <p>The entry is supposed to show warnings and then print:</p>
 <pre><code>    Hello World.</code></pre>
-<p>Can you help us?</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_vern">
 <h2 id="vern">1992/vern</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-16">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992vernvern.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/vern/vern.c">1992/vern/vern.c</a></h3>
 <h3 id="information-1992vernindex.html">Information: <a href="1992/vern/index.html">1992/vern/index.html</a></h3>
 <p>When your own checkmate is imminent it prints <code>"Har har"</code> but does not exit so
 it can ‘<em>rub your nose in defeat</em>’, as the author puts it. You will have to exit
 it yourself through ctrl-c or killing it in some other fashion.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1992_westley">
 <h2 id="westley-3">1992/westley</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-17">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1992westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1992/westley/westley.c">1992/westley/westley.c</a></h3>
 <h3 id="information-1992westleyindex.html">Information: <a href="1992/westley/index.html">1992/westley/index.html</a></h3>
@@ -1268,14 +1366,17 @@ at 80 columns. However due to the nature of the program if the terminal is &lt; 
 in column width it will not display right. To see the number of columns in your
 terminal try:</p>
 <pre><code>    echo $COLUMNS</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1993">
 <h1 id="section-9">1993</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_ant">
 <h2 id="ant">1993/ant</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-18">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993antant.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/ant/ant.c">1993/ant/ant.c</a></h3>
 <h3 id="information-1993antindex.html">Information: <a href="1993/ant/index.html">1993/ant/index.html</a></h3>
@@ -1286,18 +1387,21 @@ terminal try:</p>
 <p>There is no check for unbalanced brackets. Omitting a closing bracket will
 generate a “Pattern too long” error, which is not the real error.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_cmills">
 <h2 id="cmills">1993/cmills</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-4">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-1993cmillscmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/cmills/cmills.c">1993/cmills/cmills.c</a></h3>
 <h3 id="information-1993cmillsindex.html">Information: <a href="1993/cmills/index.html">1993/cmills/index.html</a></h3>
 <p>In multiple platforms, both macOS and also linux (in particular a RHEL 9.3
 system), this entry just shows a blank screen.</p>
-<p>Can you fix it? We welcome your help.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_lmfjyh">
 <h2 id="lmfjyh">1993/lmfjyh</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-19">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993lmfjyhlmfjyh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/lmfjyh/lmfjyh.c">1993/lmfjyh/lmfjyh.c</a></h3>
 <h3 id="information-1993lmfjyhindex.html">Information: <a href="1993/lmfjyh/index.html">1993/lmfjyh/index.html</a></h3>
@@ -1305,9 +1409,11 @@ system), this entry just shows a blank screen.</p>
 cannot be fixed for modern systems as the bug is long gone.</p>
 <p>An alternate version that will work for modern systems, however, does exist. See
 the index.html file for details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_rince">
 <h2 id="rince">1993/rince</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-20">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/rince/rince.c">1993/rince/rince.c</a></h3>
 <h3 id="information-1993rinceindex.html">Information: <a href="1993/rince/index.html">1993/rince/index.html</a></h3>
@@ -1315,9 +1421,11 @@ the index.html file for details.</p>
 will cause problems. No other checks are performed either.</p>
 <p>There is no end of game checking function so you will have to quit the game
 through ctrl-c or such.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_schnitzi">
 <h2 id="schnitzi">1993/schnitzi</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-21">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/schnitzi/schnitzi.c">1993/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1993schnitziindex.html">Information: <a href="1993/schnitzi/index.html">1993/schnitzi/index.html</a></h3>
@@ -1343,10 +1451,12 @@ question you might cause an error. For instance don’t do this:</p>
 <p>with the program terminating. Other characters will also cause this problem.</p>
 <p>Of course if you do something like:</p>
 <pre><code>    What is &#39;foo&#39;?</code></pre>
-<p>it will work fine.</p>
+<p>it will work fine. This is a feature, not a bug!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1993_vanb">
 <h2 id="vanb">1993/vanb</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-22">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1993vanbvanb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1993/vanb/vanb.c">1993/vanb/vanb.c</a></h3>
 <h3 id="information-1993vanbindex.html">Information: <a href="1993/vanb/index.html">1993/vanb/index.html</a></h3>
@@ -1355,14 +1465,17 @@ question you might cause an error. For instance don’t do this:</p>
 spurious results.</p>
 <p>The unary <code>-</code> is an operator so decimal <code>-46</code> should be entered as <code>-d46</code> and
 not <code>d-46</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1994">
 <h1 id="section-10">1994</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_dodsond2">
 <h2 id="dodsond2">1994/dodsond2</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-23">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994dodsond2dodsond2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/dodsond2/dodsond2.c">1994/dodsond2/dodsond2.c</a></h3>
 <h3 id="information-1994dodsond2index.html">Information: <a href="1994/dodsond2/index.html">1994/dodsond2/index.html</a></h3>
@@ -1371,9 +1484,11 @@ not <code>d-46</code>.</p>
 <p>Also, when you shoot it will move you to that room so if you end up shooting
 into a pit room you will end up dying even though you didn’t explicitly move
 there.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_ldb">
 <h2 id="ldb">1994/ldb</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-24">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994ldbldb.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/ldb/ldb.c">1994/ldb/ldb.c</a></h3>
 <h3 id="information-1994ldbindex.html">Information: <a href="1994/ldb/index.html">1994/ldb/index.html</a></h3>
@@ -1391,9 +1506,11 @@ real problem and as a one liner it’s already quite long.</p>
 <p>See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for more information on the change to <code>fgets(3)</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_schnitzi">
 <h2 id="schnitzi-1">1994/schnitzi</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-uses-gets---change-to-fgets-if-possible-1">STATUS: uses gets() - change to fgets() if possible</h3>
 <h3 id="source-code-1994schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/schnitzi/schnitzi.c">1994/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1994schnitziindex.html">Information: <a href="1994/schnitzi/index.html">1994/schnitzi/index.html</a></h3>
@@ -1422,6 +1539,7 @@ compile and there’s a further problem in that <code>fgets(3)</code> retains th
 whereas <code>gets(3)</code> does not). Nevertheless looking at these commands will be of
 help to understand how it works, in case one wishes to try and fix it.</p>
 <p>For the alternate versions the other functionality is unaffected.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="the-magic-of-1994schnitzi-and-how-it-flips-text">The magic of <a href="1994/schnitzi/index.html">1994/schnitzi</a> and how it flips text</h3>
 <p>The problem is getting the generated code to use <code>fgets()</code> (once it even
 compiles which was easy to do) and also have the updated buffer size be the
@@ -1462,6 +1580,7 @@ variable.</p>
 provide the correct input in comments or possibly by rearranging some of the
 code (this was actually required to make the generated code compile at all when
 changing the buffer size, see below).</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="important-points">Important points:</h3>
 <p>Getting this entry to use <code>fgets(3)</code> is easy but the problem is you’re supposed
 to be able to feed the source to the program and the output of that will be
@@ -1475,14 +1594,17 @@ can cause a compilation error! Make sure that the output of:</p>
 <pre><code>    ./schnitzi &lt; schnitzi.c</code></pre>
 <p>can be compiled and the output of that new program when fed itself can also be
 compiled!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_shapiro">
 <h2 id="shapiro">1994/shapiro</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-25">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994shapiroshapiro.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/shapiro/shapiro.c">1994/shapiro/shapiro.c</a></h3>
 <h3 id="information-1994shapiroindex.html">Information: <a href="1994/shapiro/index.html">1994/shapiro/index.html</a></h3>
 <p>This program will likely crash if the source code file (by the name of the file
 that’s compiled) cannot be opened in the directory it is run from.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="important-reminder-and-a-note-about-the--1-value-check-for-getc">Important reminder and a note about the <code>-1</code> value check for <code>getc()</code>:</h3>
 <p>This code was fixed to not use <code>-1</code> for the return value of <code>getc()</code>; this is
 important because <code>EOF</code> is <strong>NOT</strong> guaranteed to be <code>-1</code> but rather any negative
@@ -1497,16 +1619,16 @@ condition check that the return value is &gt;= 0 does not cause a compilation er
 and it functions correctly it will address the systems where <code>EOF != -1</code> just as
 if it checked for <code>!= EOF</code>.</p>
 <p>Since it works there is no need to fix this except for a challenge to yourself.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-file---please-provide-it">STATUS: missing file - please provide it</h3>
 <p>The index.html file refers to an alternate version of the code that is not
 obfuscated but it is missing from the entry directory and the archive. Do you
 have this file?</p>
-<p>We would be grateful if you could provide it to us. If you can provide this
-file you might consider removing this status from this file as well but if not
-we’ll take care of it.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1994_tvr">
 <h2 id="tvr">1994/tvr</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-26">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1994tvrtvr.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1994/tvr/tvr.c">1994/tvr/tvr.c</a></h3>
 <h3 id="information-1994tvrindex.html">Information: <a href="1994/tvr/index.html">1994/tvr/index.html</a></h3>
@@ -1519,14 +1641,17 @@ fix it without breaking something else?</p>
 <p>However, the author stated that this is a feature so this should not be fixed.
 See also the other <a href="1994/tvr/index.html#bugs">bugs</a> the author mentioned that,
 as documented, are considered features.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1995">
 <h1 id="section-11">1995</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_cdua">
 <h2 id="cdua">1995/cdua</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-27">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995cduacdua.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/cdua/cdua.c">1995/cdua/cdua.c</a></h3>
 <h3 id="information-1995cduaindex.html">Information: <a href="1995/cdua/index.html">1995/cdua/index.html</a></h3>
@@ -1537,9 +1662,11 @@ prompt you to press return again. This was thought to be a bug but looking at
 the code it can clearly be seen that if <code>g - a</code> is 0 then the message is
 supposed to be printed again and one is supposed to press a key as at that point
 it calls <code>getchar()</code> via the pointer <code>m</code>. So this is a feature not a bug.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_leo">
 <h2 id="leo">1995/leo</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-5">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-1995leoleo.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/leo/leo.c">1995/leo/leo.c</a></h3>
 <h3 id="information-1995leoindex.html">Information: <a href="1995/leo/index.html">1995/leo/index.html</a></h3>
@@ -1555,40 +1682,48 @@ to work at all even if one redirects to a file (like the workaround for the
 first) as it appears to just block.</p>
 <p>It is not known if this is platform specific but this was observed in macOS and
 it would be good if it was fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_savastio">
 <h2 id="savastio">1995/savastio</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-28">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1995savastiosavastio.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/savastio/savastio.c">1995/savastio/savastio.c</a></h3>
 <h3 id="information-1995savastioindex.html">Information: <a href="1995/savastio/index.html">1995/savastio/index.html</a></h3>
 <p>This program expects a POSITIVE number. If you specify a negative number it will
 not show any output, stuck in a loop.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1995_vanschnitz">
 <h2 id="vanschnitz">1995/vanschnitz</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-file---please-provide-it-1">STATUS: missing file - please provide it</h3>
 <h3 id="source-code-1995vanschnitzvanschnitz.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1995/vanschnitz/vanschnitz.c">1995/vanschnitz/vanschnitz.c</a></h3>
 <h3 id="information-1995vanschnitzindex.html">Information: <a href="1995/vanschnitz/index.html">1995/vanschnitz/index.html</a></h3>
 <p>The authors stated that they included a version that allows people with just K&amp;R
 compilers to use the program but this file is missing. Can you provide it?</p>
-<p>We would appreciate anyone who has it or even just knows the name! Thank you.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1996">
 <h1 id="section-12">1996</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_gandalf">
 <h2 id="gandalf">1996/gandalf</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them">STATUS: missing or dead link or links - please provide it or them</h3>
 <h3 id="source-code-1996gandalfgandalf.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/gandalf/gandalf.c">1996/gandalf/gandalf.c</a></h3>
 <h3 id="information-1996gandalfindex.html">Information: <a href="1996/gandalf/index.html">1996/gandalf/index.html</a></h3>
 <p>The link was <code>http://www.tc3.co.uk/~gandalf/G.HTML</code> but this no longer exists as
 it was instead requiring a login / password.</p>
 <p>Do you have an updated link? We welcome your help!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_huffman">
 <h2 id="huffman">1996/huffman</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-uses-gets---change-to-fgets-if-possible-2">STATUS: uses gets() - change to fgets() if possible</h3>
 <h3 id="source-code-1996huffmanhuffman.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/huffman/huffman.c">1996/huffman/huffman.c</a></h3>
 <h3 id="information-1996huffmanindex.html">Information: <a href="1996/huffman/index.html">1996/huffman/index.html</a></h3>
@@ -1620,9 +1755,11 @@ almost be done except that some of the output of the
        { a       =  0; y     (                  a       [     b  ]</code></pre>
 <p>But since it does not for the time being it is advisable to just redirect
 <code>stderr</code> to <code>/dev/null</code> (<code>2&gt;/dev/null</code>).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1996_jonth">
 <h2 id="jonth">1996/jonth</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-29">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1996jonthjonth.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/jonth/jonth.c">1996/jonth/jonth.c</a></h3>
 <h3 id="information-1996jonthindex.html">Information: <a href="1996/jonth/index.html">1996/jonth/index.html</a></h3>
@@ -1630,24 +1767,29 @@ almost be done except that some of the output of the
 This should NOT be fixed.</p>
 <p><strong>NOTE</strong>: the two boards will be on top of each other so you will have to drag one
 off the other so that you can properly play.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them-1">STATUS: missing or dead link or links - please provide it or them</h3>
 <p>As well: the link which was <code>http://www.uio.no/~jonth</code> is no longer valid and
 there’s no archive on the Internet Wayback Machine. Do you know of a proper URL?
 We greatly appreciate your help here!</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1997">
 <h1 id="section-13">1997</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 1997.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1998">
 <h1 id="section-14">1998</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_chaos">
 <h2 id="chaos">1998/chaos</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-30">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1998chaoschaos.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/chaos/chaos.c">1998/chaos/chaos.c</a></h3>
 <h3 id="information-1998chaosindex.html">Information: <a href="1998/chaos/index.html">1998/chaos/index.html</a></h3>
@@ -1673,9 +1815,11 @@ core is a popular result.)</p>
 from the rear) looks really odd. And it sometimes hangs. So just don’t fly
 through objects. You’ll be happier.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_dlowe">
 <h2 id="dlowe">1998/dlowe</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them-2">STATUS: missing or dead link or links - please provide it or them</h3>
 <h3 id="source-code-1998dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dlowe/dlowe.c">1998/dlowe/dlowe.c</a></h3>
 <h3 id="information-1998dloweindex.html">Information: <a href="1998/dlowe/index.html">1998/dlowe/index.html</a></h3>
@@ -1685,9 +1829,11 @@ for security in modern days!</strong>). Do you have a server with enough bandwid
 would like to set it up? We’ll gladly thank you in the <a href="thanks-for-help.html">thanks
 file</a> file and link to the page as well! You’ll also have
 IOCCC fame for reviving a pootifier! :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_dloweneil">
 <h2 id="dloweneil">1998/dloweneil</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them-3">STATUS: missing or dead link or links - please provide it or them</h3>
 <h3 id="source-code-1998dloweneildloweneil.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/dloweneil/dloweneil.c">1998/dloweneil/dloweneil.c</a></h3>
 <h3 id="information-1998dloweneilindex.html">Information: <a href="1998/dloweneil/index.html">1998/dloweneil/index.html</a></h3>
@@ -1697,9 +1843,11 @@ for security in modern days!</strong>). Do you have a server with enough bandwid
 would like to set it up? We’ll gladly thank you in the <a href="thanks-for-help.html">thanks
 file</a> file and link to the page as well! You’ll also have
 IOCCC fame for reviving a pootifier! :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="1998_schnitzi">
 <h2 id="schnitzi-2">1998/schnitzi</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-31">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-1998schnitzischnitzi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1998/schnitzi/schnitzi.c">1998/schnitzi/schnitzi.c</a></h3>
 <h3 id="information-1998schnitziindex.html">Information: <a href="1998/schnitzi/index.html">1998/schnitzi/index.html</a></h3>
@@ -1713,20 +1861,24 @@ be a problem including a segfault.</p>
 <p>If you use the generated program and do not give enough numbers in input
 something funny will happen, very possibly with different results per run. This
 is in the index.html file as something to try and ponder.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1999">
 <h1 id="section-15">1999</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 1999.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2000">
 <h1 id="section-16">2000</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_dlowe">
 <h2 id="dlowe-1">2000/dlowe</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-6">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-2000dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/dlowe/dlowe.c">2000/dlowe/dlowe.c</a></h3>
 <h3 id="information-2000dloweindex.html">Information: <a href="2000/dlowe/index.html">2000/dlowe/index.html</a></h3>
@@ -1752,7 +1904,7 @@ see that it does indeed crash!</p>
 <pre><code>    $ echo &quot;7 P 6 d P P 8 p&quot; | ./dlowe 2&gt;foo 1&gt;&amp;1
     7668
     $ cat foo</code></pre>
-<p>.. so at this hour it does appear to be writing to stdout but yet somehow it doesn’t? But watch:</p>
+<p>.. so it does appear to be writing to stdout but yet somehow it doesn’t? But watch:</p>
 <pre><code>    $ echo &quot;7 P 6 d P P 8 p&quot; | ./dlowe 1&gt;foo 1&gt;&amp;1
     $ cat foo
     $</code></pre>
@@ -1856,6 +2008,7 @@ on the stack at that point:</p>
     unimplemented
     5</code></pre>
 <p>which might (?) suggest that the <code>+</code> operator is unimplemented.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-32">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states that in perl &lt; 5.6.0 there is a bug with a core dump in what
 they said is in <code>Perl_sv_upgrade</code>. As this is documented it is not considered a
@@ -1895,9 +2048,11 @@ crash this makes sense.</p>
 likely print different warnings when compiling. It was observed that with
 Homebrew it does not report any warnings but with MacPorts it results in a total
 of 92 warnings! Nonetheless neither works okay and both crash.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_primenum">
 <h2 id="primenum">2000/primenum</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-33">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000primenumprimenum.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/primenum/primenum.c">2000/primenum/primenum.c</a></h3>
 <h3 id="information-2000primenumindex.html">Information: <a href="2000/primenum/index.html">2000/primenum/index.html</a></h3>
@@ -1913,23 +2068,28 @@ fix this.</p>
 try to fix the crashing of this code except to challenge yourself (if you think
 that it’ll be worth your two second fix :-) ). If you do fix it please do not
 make a pull request.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2000_rince">
 <h2 id="rince-1">2000/rince</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-34">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2000rincerince.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2000/rince/rince.c">2000/rince/rince.c</a></h3>
 <h3 id="information-2000rinceindex.html">Information: <a href="2000/rince/index.html">2000/rince/index.html</a></h3>
 <p>If <code>DISPLAY</code> is not set the program will very likely crash, do something strange
 (or if you’re very unlucky your computer might <a href="https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)">halt and catch
 fire</a>! :-) ).</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2001">
 <h1 id="section-17">2001</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_anonymous">
 <h2 id="anonymous">2001/anonymous</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-35">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001anonymousanonymous.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/anonymous/anonymous.c">2001/anonymous/anonymous.c</a></h3>
 <h3 id="information-2001anonymousindex.html">Information: <a href="2001/anonymous/index.html">2001/anonymous/index.html</a></h3>
@@ -1946,10 +2106,13 @@ it will not modify the target executable (this part of the fix at least should
 be correct).</p>
 <p>Note also that if you don’t specify a file or you specify a non-32-bit ELF file
 this program will very likely crash or do something strange like slaughter the
-elves of Imladris :-(</p>
+<a href="https://www.glyphweb.com/arda/e/elves.html">Elves</a> of
+<a href="https://www.glyphweb.com/arda/i/imladris.php">Imladris</a> :-(</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_bellard">
 <h2 id="bellard">2001/bellard</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-36">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001bellardbellard.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/bellard/bellard.c">2001/bellard/bellard.c</a></h3>
 <h3 id="information-2001bellardindex.html">Information: <a href="2001/bellard/index.html">2001/bellard/index.html</a></h3>
@@ -1974,6 +2137,7 @@ and the modification but it appears this <em>also</em> requires i386 linux; inde
 looking at the code it hard codes paths that are i386 specific to linux.</p>
 <p>Another point of interest is that the author provided unobfuscated versions
 which might be of value to look at.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h4 id="aside-why-were-there-changes-made-if-inabiaf">Aside: why were there changes made if INABIAF ?</h4>
 <p>This is a good question. The reason is we believe it better to fix some obvious
 problems: there were some bugs that would very possibly prevent it from working
@@ -1984,37 +2148,45 @@ won’t work there.</p>
 <p>Also the supplementary program, which did not work at all, was fixed and it can
 be run by itself for fun in modern systems, which was not possible before the
 fixes there.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_cheong">
 <h2 id="cheong">2001/cheong</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-37">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001cheongcheong.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/cheong/cheong.c">2001/cheong/cheong.c</a></h3>
 <h3 id="information-2001cheongindex.html">Information: <a href="2001/cheong/index.html">2001/cheong/index.html</a></h3>
 <p>This program will crash without an arg.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_dgbeards">
 <h2 id="dgbeards">2001/dgbeards</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-38">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001dgbeardsdgbeards.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/dgbeards/dgbeards.c">2001/dgbeards/dgbeards.c</a></h3>
 <h3 id="information-2001dgbeardsindex.html">Information: <a href="2001/dgbeards/index.html">2001/dgbeards/index.html</a></h3>
 <p>This program deliberately crashes if it loses (which is what it aims to do).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_herrmann1">
 <h2 id="herrmann1">2001/herrmann1</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-files---please-provide-them">STATUS: missing files - please provide them</h3>
 <h3 id="source-code-2001herrmann1herrmann1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/herrmann1.c">2001/herrmann1/herrmann1.c</a></h3>
 <h3 id="information-2001herrmann1index.html">Information: <a href="2001/herrmann1/index.html">2001/herrmann1/index.html</a></h3>
 <p>The author referred to the file <code>herrmann1.turing</code> but it does not exist not even
 in the archive. Do you have a copy? Please provide it!</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-7">STATUS: known bug - please help us fix</h3>
 <p>There is also a bug in part. During compilation you’re supposed to see some
 animation but this does not seem to work with modern gcc versions. It appears
 that version 2.95 works but maybe others do as well. Do you have a fix? We would
 appreciate your help!</p>
-<p>If you want to try and fix this, you are welcome to try.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_kev">
 <h2 id="kev">2001/kev</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-39">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001kevkev.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/kev/kev.c">2001/kev/kev.c</a></h3>
 <h3 id="information-2001kevindex.html">Information: <a href="2001/kev/index.html">2001/kev/index.html</a></h3>
@@ -2030,27 +2202,34 @@ program can segfault.</p>
 points.</p>
 <p>Although it is independent of endianness both systems need the same character
 set. In other words both have to be ASCII or EBCDIC - not one of each.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_ollinger">
 <h2 id="ollinger">2001/ollinger</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-40">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001ollingerollinger.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/ollinger/ollinger.c">2001/ollinger/ollinger.c</a></h3>
 <h3 id="information-2001ollingerindex.html">Information: <a href="2001/ollinger/index.html">2001/ollinger/index.html</a></h3>
 <p>This program will very likely crash or do something unexpected if you do not
 provide enough args.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_rosten">
 <h2 id="rosten">2001/rosten</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-41">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001rostenrosten.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/rosten/rosten.c">2001/rosten/rosten.c</a></h3>
 <h3 id="information-2001rostenindex.html">Information: <a href="2001/rosten/index.html">2001/rosten/index.html</a></h3>
 <p>See list of bugs <a href="2001/rosten/index.html#bugs">here</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-files---please-provide-them-1">STATUS: missing files - please provide them</h3>
 <p>The author stated that there is a cat man page for this program in case one
 wanted to install it as a tool but this is missing.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_schweikh">
 <h2 id="schweikh">2001/schweikh</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-42">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2001schweikhschweikh.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/schweikh/schweikh.c">2001/schweikh/schweikh.c</a></h3>
 <h3 id="information-2001schweikhindex.html">Information: <a href="2001/schweikh/index.html">2001/schweikh/index.html</a></h3>
@@ -2058,14 +2237,17 @@ wanted to install it as a tool but this is missing.</p>
 details and a workaround.</p>
 <p>There’s also no way to escape meta characters.</p>
 <p>See also the author’s list of bugs <a href="2001/schweikh/index.html#bugs">here</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_westley">
 <h2 id="westley-4">2001/westley</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-uses-gets---change-to-fgets-if-possible-3">STATUS: uses gets() - change to fgets() if possible</h3>
 <h3 id="source-code-2001westleywestley.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/westley/westley.c">2001/westley/westley.c</a></h3>
 <h3 id="information-2001westleyindex.html">Information: <a href="2001/westley/index.html">2001/westley/index.html</a></h3>
 <p>This function uses <code>gets(3)</code> but it would be ideal if it used <code>fgets(3)</code>. This
 one is rather complicated but you are welcome to try and fix this if you wish.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-main-has-only-one-arg---try-and-make-it-have-2-or-3">STATUS: main() has only one arg - try and make it have 2 or 3</h3>
 <p>This program only has one arg to <code>main()</code>. However changing it to have 2 is not
 as simple as it might seem. Doing this breaks things. If memory serves changing
@@ -2077,12 +2259,15 @@ does too. You might try running the <code>try.sh</code> script and redirect it t
 first so that you can compare the output. Make sure to recreate the extra files
 as described by the author if you do fix this. This might be looked at later if
 nobody else takes up the challenge.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-files---please-provide-them-2">STATUS: missing files - please provide them</h3>
 <p>The author referred to a file <code>card.gif</code> but this file is missing. Do you have
 it? Please provide it!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2001_williams">
 <h2 id="williams">2001/williams</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-8">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-2001williamswilliams.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/williams/williams.c">2001/williams/williams.c</a></h3>
 <h3 id="information-2001williamsindex.html">Information: <a href="2001/williams/index.html">2001/williams/index.html</a></h3>
@@ -2115,26 +2300,31 @@ to be the case (though this was not tried as many times) if you start shooting
 when the missiles come down. The fact you can shoot after it starts that
 sleeping in a loop does suggest that it’s not stuck only showing those lines and
 sleeping.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2002">
 <h1 id="section-18">2002</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2002.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2003">
 <h1 id="section-19">2003</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2003.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2004">
 <h1 id="section-20">2004</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_gavin">
 <h2 id="gavin">2004/gavin</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-43">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004gavingavin.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/gavin/gavin.c">2004/gavin/gavin.c</a></h3>
 <h3 id="information-2004gavinindex.html">Information: <a href="2004/gavin//index.html">2004/gavin//index.html</a></h3>
@@ -2150,6 +2340,7 @@ to let it compile with clang.</p>
          -u command line option
          (maybe you meant: __start)
     ld: symbol(s) not found for architecture arm64</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <h4 id="recent-2004gavin-mods">Recent 2004/gavin mods:</h4>
 <p>Although not related some recent changes were made to
 <a href="2004/gavin/index.html">2004/gavin</a> to let it
@@ -2222,9 +2413,11 @@ fit into the current IOCCC build environment.</p>
 <p>Please also see <a href="2004/gavin/index.html#known-features">known features in the
 index.html</a> for things that are not bugs
 but documented (mis)features.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_hibachi">
 <h2 id="hibachi">2004/hibachi</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-44">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004hibachihibachi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/hibachi/hibachi.c">2004/hibachi/hibachi.c</a></h3>
 <h3 id="information-2004hibachiindex.html">Information: <a href="2004/hibachi//index.html">2004/hibachi//index.html</a></h3>
@@ -2233,9 +2426,11 @@ but documented (mis)features.</p>
 <p>The links (text) web browser does not support RFC 2616 section 7.2.1 paragraph 3
 sentence 2, and so fails to display responses from <code>hibachi</code>.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_jdalbec">
 <h2 id="jdalbec">2004/jdalbec</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-45">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004jdalbecjdalbec.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/jdalbec/jdalbec.c">2004/jdalbec/jdalbec.c</a></h3>
 <h3 id="information-2004jdalbecindex.html">Information: <a href="2004/jdalbec/index.html">2004/jdalbec/index.html</a></h3>
@@ -2255,22 +2450,27 @@ runs of the same symbol.</p>
 results (e.g., generation 1 starting from a string of 257 <code>1</code>s will be
 calculated as <code>11</code>); the remark from the previous paragraph applies here also.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2004_sds">
 <h2 id="sds">2004/sds</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-46">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2004sdssds.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2004/sds/sds.c">2004/sds/sds.c</a></h3>
 <h3 id="information-2004sdsindex.html">Information: <a href="2004/sds/index.html">2004/sds/index.html</a></h3>
 <p>The generated code will very likely segfault or do something not intended if not
 given the right args. See the index.html file for the correct syntax.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2005">
 <h1 id="section-21">2005</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_anon">
 <h2 id="anon">2005/anon</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-47">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005anonanon.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/anon/anon.c">2005/anon/anon.c</a></h3>
 <h3 id="information-2005anonindex.html">Information: <a href="2005/anon/index.html">2005/anon/index.html</a></h3>
@@ -2282,9 +2482,11 @@ details on this.</p>
 <p>If you specify more than three args the program might also crash or do something
 strange. This might also happen if you specify excessively large board
 dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_giljade">
 <h2 id="giljade">2005/giljade</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-48">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005giljadegiljade.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/giljade/giljade.c">2005/giljade/giljade.c</a></h3>
 <h3 id="information-2005giljadeindex.html">Information: <a href="2005/giljade/index.html">2005/giljade/index.html</a></h3>
@@ -2292,9 +2494,11 @@ dimensions. Try <code>100 100 100</code> for instance and see what happens!</p>
 does not exist.</p>
 <p>This entry will, according to the author, likely segfault if <code>sizeof(int) != sizeof(FILE *)</code>.</p>
 <p>This entry requires that <code>sed</code> and <code>make</code> are in your <code>$PATH</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_mikeash">
 <h2 id="mikeash">2005/mikeash</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-49">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mikeashmikeash.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mikeash/mikeash.c">2005/mikeash/mikeash.c</a></h3>
 <h3 id="information-2005mikeashindex.html">Information: <a href="2005/mikeash/index.html">2005/mikeash/index.html</a></h3>
@@ -2327,9 +2531,11 @@ nowhere near
 <p>Basically, the LISP interpreter is good for some basic math operations, and
 for running itself.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_mynx">
 <h2 id="mynx">2005/mynx</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-50">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005mynxmynx.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/mynx/mynx.c">2005/mynx/mynx.c</a></h3>
 <h3 id="information-2005mynxindex.html">Information: <a href="2005/mynx/index.html">2005/mynx/index.html</a></h3>
@@ -2341,9 +2547,11 @@ first be set up in order to give http commands. This is not a bug but it’s wor
 pointing out as it won’t work on as many websites as it used to including the
 <a href="https://www.ioccc.org">IOCCC website</a> itself. The author noted that someone did
 make a version that supports <code>https</code> but it is not known where this might be.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2005_sykes">
 <h2 id="sykes">2005/sykes</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-51">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2005sykessykes.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2005/sykes/sykes.c">2005/sykes/sykes.c</a></h3>
 <h3 id="information-2005sykesindex.html">Information: <a href="2005/sykes/index.html">2005/sykes/index.html</a></h3>
@@ -2365,14 +2573,17 @@ not run correctly.</p>
 <a href="https://en.wikipedia.org/wiki/MOS_Technology_6502#Technical_description">6502</a>
 <a href="https://en.wikipedia.org/wiki/Emulator">emulation</a> does not include the seldom
 used decimal mode, or any of the “undocumented” instructions.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2006">
 <h1 id="section-22">2006</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_birken">
 <h2 id="birken">2006/birken</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-uses-gets---change-to-fgets-if-possible-4">STATUS: uses gets() - change to fgets() if possible</h3>
 <h3 id="source-code-2006birkenbirken.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/birken/birken.c">2006/birken/birken.c</a></h3>
 <h3 id="information-2006birkenindex.html">Information: <a href="2006/birken/index.html">2006/birken/index.html</a></h3>
@@ -2382,25 +2593,31 @@ obnoxious in macOS as it shows it at runtime (redirecting <code>stderr</code> to
 with at least <code>computer.tofu</code> input file:</p>
 <pre><code>    12a13
     #define gets(c) fgets((c),PI,stdin)&amp;&amp;(((c)[strlen((c))-1]=&#39;\0&#39;),c!=NULL)</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_borsanyi">
 <h2 id="borsanyi">2006/borsanyi</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-52">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/borsanyi/borsanyi.c">2006/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2006borsanyiindex.html">Information: <a href="2006/borsanyi/index.html">2006/borsanyi/index.html</a></h3>
 <p>The string specified must be &lt;= 42 characters and may only consist of the
 characters in the regex <code>a-z_A-Z0-9@.-</code>. Breaking these constraints will end up
 with possibly corrupt GIF files.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_hamre">
 <h2 id="hamre">2006/hamre</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-53">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006hamrehamre.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/hamre/hamre.c">2006/hamre/hamre.c</a></h3>
 <h3 id="information-2006hamreindex.html">Information: <a href="2006/hamre/index.html">2006/hamre/index.html</a></h3>
 <p>This program will likely crash or do something funny without an arg.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_monge">
 <h2 id="monge">2006/monge</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-doesnt-work-with-some-platforms---please-help-us-fix-it">STATUS: doesn’t work with some platforms - please help us fix it</h3>
 <h3 id="source-code-2006mongemonge.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/monge/monge.c">2006/monge/monge.c</a></h3>
 <h3 id="information-2006mongeindex.html">Information: <a href="2006/monge/index.html">2006/monge/index.html</a></h3>
@@ -2413,19 +2630,24 @@ but you are welcome to try and fix it.</p>
 provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-54">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>Incorrect formulas will ungracefully crash the program.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_stewart">
 <h2 id="stewart">2006/stewart</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-55">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006stewartstewart.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/stewart/stewart.c">2006/stewart/stewart.c</a></h3>
 <h3 id="information-2006stewartindex.html">Information: <a href="2006/stewart/index.html">2006/stewart/index.html</a></h3>
 <p>This program will likely crash or do something funny if the file cannot be
 opened. The number of args is however checked.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_sykes1">
 <h2 id="sykes1">2006/sykes1</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-56">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006sykes1sykes1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/sykes1/sykes1.c">2006/sykes1/sykes1.c</a></h3>
 <h3 id="information-2006sykes1index.html">Information: <a href="2006/sykes1/index.html">2006/sykes1/index.html</a></h3>
@@ -2440,9 +2662,11 @@ result in the 19186 unique solutions.</p>
 <p>If you pick a number higher than 460464 (24x19186) the program will return
 without outputting a solution. If you can wait that long.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2006_toledo2">
 <h2 id="toledo2">2006/toledo2</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-57">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2006toledo2toledo2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2006/toledo2/toledo2.c">2006/toledo2/toledo2.c</a></h3>
 <h3 id="information-2006toledo2index.html">Information: <a href="2006/toledo2/index.html">2006/toledo2/index.html</a></h3>
@@ -2458,38 +2682,45 @@ longer seems to happen but we don’t need this to be added even if it might
 be called a bug :-)</p>
 <p>You must type in caps (except in strings) and this program is indeed
 case-sensitive.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2007">
 <h1 id="section-23">2007</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2007.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2008">
 <h1 id="section-24">2008</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2008.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2009">
 <h1 id="section-25">2009</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2009.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2010">
 <h1 id="section-26">2010</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2010.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2011">
 <h1 id="section-27">2011</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_borsanyi">
 <h2 id="borsanyi-1">2011/borsanyi</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-58">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011borsanyiborsanyi.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/borsanyi/borsanyi.c">2011/borsanyi/borsanyi.c</a></h3>
 <h3 id="information-2011borsanyiindex.html">Information: <a href="2011/borsanyi/index.html">2011/borsanyi/index.html</a></h3>
@@ -2505,9 +2736,11 @@ available stack space.</p></li>
 <li><p>Rounding errors might cause an omission in the highest bin. There might be
 empty bins at the edges.</p></li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_dlowe">
 <h2 id="dlowe-2">2011/dlowe</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-missing-or-dead-link-or-links---please-provide-it-or-them-4">STATUS: missing or dead link or links - please provide it or them</h3>
 <h3 id="source-code-2011dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/dlowe/dlowe.c">2011/dlowe/dlowe.c</a></h3>
 <h3 id="information-2011dloweindex.html">Information: <a href="2011/dlowe/index.html">2011/dlowe/index.html</a></h3>
@@ -2517,6 +2750,7 @@ for security in modern days!</strong>). Do you have a server with enough bandwid
 would like to set it up? We’ll gladly thank you in the <a href="thanks-for-help.html">thanks
 file</a> file and link to the page as well! You’ll also have
 IOCCC fame for reviving a pootifier! :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-59">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author states the following:</p>
 <ul>
@@ -2526,9 +2760,11 @@ tends to result in empty output.</p></li>
 <li><p>Leaks memory and file descriptors while processing files.</p></li>
 <li><p>Will crash and die horribly if it runs out of memory.</p></li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_fredriksson">
 <h2 id="fredriksson">2011/fredriksson</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-60">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011fredrikssonfredriksson.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/fredriksson/fredriksson.c">2011/fredriksson/fredriksson.c</a></h3>
 <h3 id="information-2011fredrikssonindex.html">Information: <a href="2011/fredriksson/index.html">2011/fredriksson/index.html</a></h3>
@@ -2536,13 +2772,16 @@ tends to result in empty output.</p></li>
 list is rather long see <a href="2011/fredriksson/index.html#other-features">other
 features</a> and <a href="2011/fredriksson/index.html#limitations-and-remarks">limitations and
 remarks</a> instead.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_konno">
 <h2 id="konno">2011/konno</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-61">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011konnokonno.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/konno/konno.c">2011/konno/konno.c</a></h3>
 <h3 id="information-2011konnoindex.html">Information: <a href="2011/konno/index.html">2011/konno/index.html</a></h3>
 <p>This program will very likely crash or do something funny without an arg.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_richards">
 <h2 id="richards">2011/richards</h2>
 </div>
@@ -2560,6 +2799,7 @@ work. Some earlier debugging sessions are below as well as a resource from the
 author as well as some resources on Apple’s website should anyone wish to take a
 crack at it. A starting point might be in
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/richards/richards.alt.c">richards.alt.c</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="debugging">Debugging</h3>
 <p>At first glance it appeared to be that it might be the function pointers or the
 fact it is trying to execute code in memory (as noted above). The function
@@ -2576,7 +2816,7 @@ With <code>address</code> in linux:</p>
 <pre><code>    #define W(c) e=memmove(e,x[(u)c], y[(u)c])+y[(u)c];</code></pre>
 <p>so it would appear that</p>
 <pre><code>    x[(u)c]</code></pre>
-<p>(at least in my tired head?) is NULL. But why does it work then?</p>
+<p>is NULL. But why does it work then?</p>
 <p><strong>NOTE</strong>: <code>u</code> is <code>int</code>.</p>
 <p>Under macOS (with the arm64 chip) we get:</p>
 <pre><code>    UndefinedBehaviorSanitizer:DEADLYSIGNAL
@@ -2685,13 +2925,17 @@ linux.</p>
                                  ^~</code></pre>
 <p>This can be fixed easily enough however but it doesn’t appear to matter in this
 case.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="testing-fixes">Testing fixes</h3>
 <p>It might be helpful to use the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/richards/try.alt.sh">try.alt.sh</a> script to
 test that it does not crash and functions properly.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="resources">Resources</h3>
+<p>Jump to: <a href="#">top</a></p>
 <h4 id="more-from-the-author">More from the author</h4>
 <p>The author has more about the entry at
 <a href="https://github.com/GregorR/ioccc2011" class="uri">https://github.com/GregorR/ioccc2011</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h4 id="apple-resources">Apple resources</h4>
 <p><a href="https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon?language=objc">Porting Just-In-Time Compilers to Apple
 Silicon</a></p>
@@ -2703,24 +2947,28 @@ A curious thing is in the <code>mprotect()</code> function: <code>#if CONFIG_DYN
 <code>VM_PROT_TRUSTED</code> set it might allow overriding the problem but this is
 unconfirmed and it’s not known when <code>CONFIG_DYNAMIC_CODE_SIGNING</code> would be
 defined.</p>
-<p>Do you have a fix? We welcome it!</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2011_vik">
 <h2 id="vik">2011/vik</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-62">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2011vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2011/vik/vik.c">2011/vik/vik.c</a></h3>
 <h3 id="information-2011vikindex.html">Information: <a href="2011/vik/index.html">2011/vik/index.html</a></h3>
 <p>The author stated that the program will crash if no argument is passed to the
 program though we note that your computer might also <a href="https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)">halt and catch
 fire</a> :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2012">
 <h1 id="section-28">2012</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_blakely">
 <h2 id="blakely">2012/blakely</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-63">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012blakelyblakely.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/blakely/blakely.c">2012/blakely/blakely.c</a></h3>
 <h3 id="information-2012blakelyindex.html">Information: <a href="2012/blakely/index.html">2012/blakely/index.html</a></h3>
@@ -2729,9 +2977,11 @@ fire</a> :-)</p>
 <p>If there is a division by zero, square-root of a negative number, or similar
 operation, then the results are undefined.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_deckmyn">
 <h2 id="deckmyn">2012/deckmyn</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-64">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012deckmyndeckmyn.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/deckmyn/deckmyn.c">2012/deckmyn/deckmyn.c</a></h3>
 <h3 id="information-2012deckmynindex.html">Information: <a href="2012/deckmyn/index.html">2012/deckmyn/index.html</a></h3>
@@ -2759,9 +3009,11 @@ Therefore, when preparing music in a file, care should be taken that the last
 musical element of a line is only 2 characters!</p>
 </blockquote>
 <p>The manual referred to is <a href="2012/deckmyn/deckmyn.html">here</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_dlowe">
 <h2 id="dlowe-3">2012/dlowe</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-65">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/dlowe/dlowe.c">2012/dlowe/dlowe.c</a></h3>
 <h3 id="information-2012dloweindex.html">Information: <a href="2012/dlowe/index.html">2012/dlowe/index.html</a></h3>
@@ -2773,9 +3025,11 @@ doesn’t make it possible to lock drawing to the display refresh rate.)</li>
 <code>dead.d</code> and <code>sprites.d</code>).</li>
 <li>Cannot build or run without X11 (or an X11 compatibility layer).</li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_tromp">
 <h2 id="tromp">2012/tromp</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-66">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012tromptromp.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/tromp/tromp.c">2012/tromp/tromp.c</a></h3>
 <h3 id="information-2012trompindex.html">Information: <a href="2012/tromp/index.html">2012/tromp/index.html</a></h3>
@@ -2792,9 +3046,11 @@ interpreter to crash when looking into a null-pointer environment:</p>
 <p><code>echo "&gt;Hello, world" | ./tromp</code></p>
 <p>will likely dump core.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2012_vik">
 <h2 id="vik-1">2012/vik</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-67">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2012vikvik.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2012/vik/vik.c">2012/vik/vik.c</a></h3>
 <h3 id="information-2012vikindex.html">Information: <a href="2012/vik/index.html">2012/vik/index.html</a></h3>
@@ -2803,14 +3059,17 @@ program or if invalid arguments (e.g. file does not exist) or images of
 mismatching sizes or unsupported pixel formats though we note that your computer
 might also <a href="https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_(computing)">halt and catch
 fire</a> :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2013">
 <h1 id="section-29">2013</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_cable2">
 <h2 id="cable2">2013/cable2</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-68">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013cable2cable2.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/cable2/cable2.c">2013/cable2/cable2.c</a></h3>
 <h3 id="information-2013cable2index.html">Information: <a href="2013/cable2/index.html">2013/cable2/index.html</a></h3>
@@ -2828,9 +3087,11 @@ antialiasing interferes with color detection in “color” mode.</li>
 <li>Only runs on little endian machines (since the BMP format is little endian,
 and endianness conversion would make the source too large for IOCCC rule 2).</li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_dlowe">
 <h2 id="dlowe-4">2013/dlowe</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-69">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013dlowedlowe.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/dlowe/dlowe.c">2013/dlowe/dlowe.c</a></h3>
 <h3 id="information-2013dloweindex.html">Information: <a href="2013/dlowe/index.html">2013/dlowe/index.html</a></h3>
@@ -2847,26 +3108,28 @@ something funny (or will it? :-) ) and when will it just do nothing?</p>
 <li>Only works if your terminal is UTF-8 and your font supports the 8 glyphs
 used.</li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_endoh1">
 <h2 id="endoh1">2013/endoh1</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-70">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh1endoh1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh1/endoh1.c">2013/endoh1/endoh1.c</a></h3>
 <h3 id="information-2013endoh1index.html">Information: <a href="2013/endoh1/index.html">2013/endoh1/index.html</a></h3>
 <blockquote>
 <p>This program supports only “Combinator-calculus style notation” of Lazy K.
 “Unlambda style” and “Iota and Jot” style are not supported.</p>
-</blockquote>
-<blockquote>
 <p>Also, it requires a space between identifiers. In short, use <code>(S K)</code> instead of
 <code>(SK)</code>, “`sk”, <code>**i*i*i*ii*i*i*ii</code>, or <code>11111100011100</code>.</p>
 <p>Huge memory may be required to compile the program (about 300 MB on my machine).</p>
 <p>In addition, there are some limitations (and workarounds) mentioned in the
 <a href="2013/endoh1/index.html#obfuscation">obfuscation section</a>.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_endoh3">
 <h2 id="endoh3">2013/endoh3</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-71">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh3endoh3.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh3/endoh3.c">2013/endoh3/endoh3.c</a></h3>
 <h3 id="information-2013endoh3index.html">Information: <a href="2013/endoh3/index.html">2013/endoh3/index.html</a></h3>
@@ -2877,24 +3140,30 @@ used.</li>
 <p>Can you figure out why?</p>
 <p>A workaround is inserting a whitespace: <code>C2 E2</code>.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_endoh4">
 <h2 id="endoh4">2013/endoh4</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-72">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013endoh4endoh4.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/endoh4/endoh4.c">2013/endoh4/endoh4.c</a></h3>
 <h3 id="information-2013endoh4index.html">Information: <a href="2013/endoh4/index.html">2013/endoh4/index.html</a></h3>
 <p>Invalid input files will very likely crash the program.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_hou">
 <h2 id="hou">2013/hou</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-73">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013houhou.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/hou/hou.c">2013/hou/hou.c</a></h3>
 <h3 id="information-2013houindex.html">Information: <a href="2013/hou/index.html">2013/hou/index.html</a></h3>
 <p>This program will not terminate on its own; you must kill <code>hou</code> (but not Qiming
 Hou :-) ) yourself. This should not be fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2013_mills">
 <h2 id="mills">2013/mills</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-74">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2013millsmills.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2013/mills/mills.c">2013/mills/mills.c</a></h3>
 <h3 id="information-2013millsindex.html">Information: <a href="2013/mills/index.html">2013/mills/index.html</a></h3>
@@ -2904,14 +3173,17 @@ the socket (which obviously you do). The source is out the scope of this
 document but the author does mention the well known (at least to those of us who
 have experience with socket programming :-) ) fix. However as the author pointed
 it out as a known limitation it is not a bug but a feature.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2014">
 <h1 id="section-30">2014</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_maffiodo1">
 <h2 id="maffiodo1">2014/maffiodo1</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-75">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo1/prog.c">2014/maffiodo1/prog.c</a></h3>
 <h3 id="information-2014maffiodo1index.html">Information: <a href="2014/maffiodo1/index.html">2014/maffiodo1/index.html</a></h3>
@@ -2929,17 +3201,20 @@ game you cannot go through walls but it’s not a bug.</p>
 collide with blocks and get stuck inside them. This is a KNOWN BUG. When your
 player become bigger, stay away from blocks!</p>
 </blockquote>
-<p>.. but since it’s documented it’s considered a feature, not a bug to fix.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_maffiodo2">
 <h2 id="maffiodo2">2014/maffiodo2</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-76">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2014maffiodo2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/maffiodo2/prog.c">2014/maffiodo2/prog.c</a></h3>
 <h3 id="information-2014maffiodo2index.html">Information: <a href="2014/maffiodo2/index.html">2014/maffiodo2/index.html</a></h3>
 <p>This program will very likely crash if no arg is given.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2014_vik">
 <h2 id="vik-2">2014/vik</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-9">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-2014vikprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2014/vik/prog.c">2014/vik/prog.c</a></h3>
 <h3 id="information-2014vikindex.html">Information: <a href="2014/vik/index.html">2014/vik/index.html</a></h3>
@@ -2966,47 +3241,50 @@ rely on the entry as the below shows. One should be able to do:</p>
     ./prog e &lt; ioccc.raw</code></pre>
 <p>they will properly get:</p>
 <pre><code>    IOCCC</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2015">
 <h1 id="section-31">2015</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_duble">
 <h2 id="duble">2015/duble</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-77">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/duble/prog.c">2015/duble/prog.c</a></h3>
 <h3 id="information-2015dubleindex.html">Information: <a href="2015/duble/index.html">2015/duble/index.html</a></h3>
 <p>This program is known to, in some cases, segfault, and as the judges and the
 author noted this, it should not be fixed.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_hou">
 <h2 id="hou-1">2015/hou</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-78">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/hou/prog.c">2015/hou/prog.c</a></h3>
 <h3 id="information-2015houindex.html">Information: <a href="2015/hou/index.html">2015/hou/index.html</a></h3>
 <p>The author stated:</p>
 <blockquote>
 <p>Hard requirements:</p>
-<ul>
-<li><p>The platform must implement the <code>double</code> type as IEEE754-compliant 64-bit
+<p>The platform must implement the <code>double</code> type as IEEE754-compliant 64-bit
 floating point numbers. The 80-bit intermediate format used by x87 is
 considered as an violation of this. The code should print an error message on
-such platforms.</p></li>
-<li><p>The program must start with the CPU / FPU in round-to-nearest mode.</p></li>
-</ul>
+such platforms.</p>
+<p>The program must start with the CPU / FPU in round-to-nearest mode.</p>
 <p>Soft requirements:</p>
-<ul>
-<li><p>The compiler must respect <code>volatile</code>. The code is formatted to warn about
-that, though.</p></li>
-<li><p>The printed result is only correct on little-endian machines. The program
+<p>The compiler must respect <code>volatile</code>. The code is formatted to warn about
+that, though.</p>
+<p>The printed result is only correct on little-endian machines. The program
 takes care to warn about this issue after printing an incorrect big-endian
-result. Error messages become garbled, though.</p></li>
-</ul>
+result. Error messages become garbled, though.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_howe">
 <h2 id="howe">2015/howe</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-10">STATUS: known bug - please help us fix</h3>
 <p>The test scripts do not seem to work properly with bash but this would be ideal
 as not all systems have a compatible shell (they assume a POSIX compliant
@@ -3023,18 +3301,22 @@ shell). One, with bash, might see:</p>
 <p>The same problem exists in the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/howe/prog.alt-test.sh">prog.alt-test.sh</a>, particularly
 because it is the same thing as the other, just updated to use <code>prog.alt</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_mills2">
 <h2 id="mills2">2015/mills2</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-79">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015mills2prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/mills2/prog.c">2015/mills2/prog.c</a></h3>
 <h3 id="information-2015mills2index.html">Information: <a href="2015/mills2/index.html">2015/mills2/index.html</a></h3>
 <p>The program doesn’t look at the header of files so if it’s passed something hat
 is not compressed data it’s likely to crash.</p>
 <p>The program depends on little endian systems.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2015_schweikhardt">
 <h2 id="schweikhardt">2015/schweikhardt</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-80">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2015schweikhardtprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2015/schweikhardt/prog.c">2015/schweikhardt/prog.c</a></h3>
 <h3 id="information-2015schweikhardtindex.html">Information: <a href="2015/schweikhardt/index.html">2015/schweikhardt/index.html</a></h3>
@@ -3048,26 +3330,31 @@ of bits in a type is <code>sizeof(typ) &lt;&lt; 3</code>, it will work correctly
 <code>int</code> and so on. On such systems, it will only use <code>8 * sizeof(typ)</code> bits per
 place. It does not work when <code>CHAR_BIT &lt;= 7</code>.</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2016">
 <h1 id="section-32">2016</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2016.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2017">
 <h1 id="section-33">2017</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2017.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2018">
 <h1 id="section-34">2018</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_algmyr">
 <h2 id="algmyr">2018/algmyr</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-81">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018algmyrprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/algmyr/prog.c">2018/algmyr/prog.c</a></h3>
 <h3 id="information-2018algmyrindex.html">Information: <a href="2018/algmyr/index.html">2018/algmyr/index.html</a></h3>
@@ -3084,9 +3371,11 @@ behavior. Some erroneous arguments cause segfaults (negative number of channels,
 channel id outside valid range). One argument in particular causes an infinite
 loop printing whitespace.</li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_hou">
 <h2 id="hou-2">2018/hou</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-82">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018houprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/hou/prog.c">2018/hou/prog.c</a></h3>
 <h3 id="information-2018houindex.html">Information: <a href="2018/hou/index.html">2018/hou/index.html</a></h3>
@@ -3099,9 +3388,11 @@ be generated properly.</p>
 <p>Some JSON files might cause the program to continue to run and seemingly
 infinitely increase the size of the output file. This can happen if you try
 fixing the syntax error in the generated <code>ioccc.json</code> file.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_mills">
 <h2 id="mills-1">2018/mills</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-11">STATUS: known bug - please help us fix</h3>
 <h3 id="source-code-2018millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/mills/prog.c">2018/mills/prog.c</a></h3>
 <h3 id="information-2018millsindex.html">Information: <a href="2018/mills/index.html">2018/mills/index.html</a></h3>
@@ -3112,6 +3403,7 @@ likely see:</p>
 <p>where <code>[]</code> is the cursor. When this happens if you hit enter (this is necessary
 or else it’ll happen again) and then exit again (ctrl-e) and run <code>prog</code> again
 it’ll be okay.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-83">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <p>The author stated that if you make a typo it can happen that the boot loader can
 crash and halt. If this is the case type ctrl-e to quit the emulator and try
@@ -3124,9 +3416,11 @@ referred to by the author but there was likely no typo involved.</p>
 <p>Another issue noticed is that if you are using the saved mode you must type
 <code>sync</code> prior to exiting the program or else the next time you run it the file
 will not exist (or in the case of compiled code it won’t be executable).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2018_vokes">
 <h2 id="vokes">2018/vokes</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-84">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2018vokesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/vokes/prog.c">2018/vokes/prog.c</a></h3>
 <h3 id="information-2018vokesindex.html">Information: <a href="2018/vokes/index.html">2018/vokes/index.html</a></h3>
@@ -3169,30 +3463,37 @@ limit.</p></li>
 the values <code>48</code> through <code>57</code>, rather than using <code>isdigit(3)</code>. As noted above,
 this program has nothing to do with a hand.</p></li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2019">
 <h1 id="section-35">2019</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_adamovsky">
 <h2 id="adamovsky">2019/adamovsky</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-85">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019adamovskyprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/prog.c">2019/adamovsky/prog.c</a></h3>
 <h3 id="information-2019adamovskyindex.html">Information: <a href="2019/adamovsky/index.html">2019/adamovsky/index.html</a></h3>
 <p>Certain input can crash this program. The file
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/adamovsky/crash.unl">crash.unl</a> is an example file.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_burton">
 <h2 id="burton">2019/burton</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-86">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/burton/prog.c">2019/burton/prog.c</a></h3>
 <h3 id="information-2019burtonindex.html">Information: <a href="2019/burton/index.html">2019/burton/index.html</a></h3>
 <p>The author pointed out that some implementations of <code>wc(1)</code> show different
 values but his implementation matches that of macOS and FreeBSD.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_ciura">
 <h2 id="ciura">2019/ciura</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-87">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019ciuraprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/ciura/prog.c">2019/ciura/prog.c</a></h3>
 <h3 id="information-2019ciuraindex.html">Information: <a href="2019/ciura/index.html">2019/ciura/index.html</a></h3>
@@ -3213,9 +3514,11 @@ noted in the de.sh/de.alt.sh scripts:</p>
     # if it&#39;s not impossible. Nevertheless, we do include the other characters
     # whether or not they are in your view considered part of the alphabet for the
     # reason that so many words have them.</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_dogon">
 <h2 id="dogon">2019/dogon</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-uses-gets---change-to-fgets-if-possible-5">STATUS: uses gets() - change to fgets() if possible</h3>
 <h3 id="source-code-2019dogonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/dogon/prog.c">2019/dogon/prog.c</a></h3>
 <h3 id="information-2019dogonindex.html">Information: <a href="2019/dogon/index.html">2019/dogon/index.html</a></h3>
@@ -3223,9 +3526,11 @@ noted in the de.sh/de.alt.sh scripts:</p>
 <p>See the
 FAQ on “<a href="faq.html#gets">gets and fgets</a>”
 for more information on the change to <code>fgets(3)</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_duble">
 <h2 id="duble-1">2019/duble</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-88">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019dubleprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/duble/prog.c">2019/duble/prog.c</a></h3>
 <h3 id="information-2019dubleindex.html">Information: <a href="2019/duble/index.html">2019/duble/index.html</a></h3>
@@ -3243,26 +3548,30 @@ Ferguson</a> showed us this:</p>
     srwxr-xr-x   1 cody  staff     0 Apr  6 08:16 .CMDGAELH=
     srwxr-xr-x   1 cody  staff     0 Apr  3 08:47 .CMLBCCDA=
     [...]</code></pre>
-<p>This is NOT a bug and you’ll have to (at least at this time?) delete the files
+<p>This is NOT a bug and you’ll have to delete the files
 manually. You shouldn’t have to worry about these being added to git: it seems
 to ignore sockets (it did at least in macOS).</p>
-<p>He provides the following tips on this situation. A simpler way to find sockets
-in the directory:</p>
+<p>Jump to: <a href="#">top</a></p>
+<p>Tips on this situation. A simpler way to find sockets in the directory:</p>
 <pre><code>    file .*|grep socket|cut -f1 -d:</code></pre>
 <p>To delete them you can do:</p>
 <pre><code>    find . -exec file &#39;{}&#39; \;|grep socket|cut -f 1 -d: | xargs rm -f</code></pre>
 <p>though one might want to check that the program is not currently running. :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_endoh">
 <h2 id="endoh">2019/endoh</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-89">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019endohprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/endoh/prog.c">2019/endoh/prog.c</a></h3>
 <h3 id="information-2019endohindex.html">Information: <a href="2019/endoh/index.html">2019/endoh/index.html</a></h3>
 <p>As a backtrace quine this entry is <strong>SUPPOSED to segfault</strong> so this should not be
 touched either.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_karns">
 <h2 id="karns">2019/karns</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-90">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019karnsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/karns/prog.c">2019/karns/prog.c</a></h3>
 <h3 id="information-2019karnsindex.html">Information: <a href="2019/karns/index.html">2019/karns/index.html</a></h3>
@@ -3283,9 +3592,13 @@ encountered this myself).</li>
 <li>The program could be obfuscated much further.</li>
 <li>The program contains some unused code and data.</li>
 </ul>
+<p><strong>NOTE</strong>: the segfault problem might have been fixed when the optimiser was disabled
+(which was necessary as part of a bug fix).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_lynn">
 <h2 id="lynn">2019/lynn</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-91">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019lynnprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/lynn/prog.c">2019/lynn/prog.c</a></h3>
 <h3 id="information-2019lynnindex.html">Information: <a href="2019/lynn/index.html">2019/lynn/index.html</a></h3>
@@ -3293,9 +3606,11 @@ encountered this myself).</li>
 expect. Rather than duplicate the information we refer you to the author’s
 remarks in the sections <a href="2019/lynn/index.html#syntax">Syntax</a> and
 <a href="2019/lynn/index.html#caveats">Caveats</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_mills">
 <h2 id="mills-2">2019/mills</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-92">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019millsprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/mills/prog.c">2019/mills/prog.c</a></h3>
 <h3 id="information-2019millsindex.html">Information: <a href="2019/mills/index.html">2019/mills/index.html</a></h3>
@@ -3314,18 +3629,22 @@ shells, you can view the hard limit with ulimit -Hs and set it with ulimit -s
 view the hard limit with limit -h stacksize and set it with limit stacksize
 65532 (replacing 65532 with the actual hard limit).</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_poikola">
 <h2 id="poikola">2019/poikola</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-93">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019poikolaprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/poikola/prog.c">2019/poikola/prog.c</a></h3>
 <h3 id="information-2019poikolaindex.html">Information: <a href="2019/poikola/index.html">2019/poikola/index.html</a></h3>
 <p>This program will not validate input so it might fail or get stuck if invoked
 erroneously.</p>
 <p>Also, the maximum file size is 1GB.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2019_yang">
 <h2 id="yang">2019/yang</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-94">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2019yangprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2019/yang/prog.c">2019/yang/prog.c</a></h3>
 <h3 id="information-2019yangindex.html">Information: <a href="2019/yang/index.html">2019/yang/index.html</a></h3>
@@ -3333,14 +3652,17 @@ erroneously.</p>
 <p>The author also stated that ‘if input contains CR-LF end of line sequences,
 those <code>CR</code>s are silently dropped. In fact, most control codes are silently
 ignored except line feeds (preserved) and tabs (expanded to 8 spaces).’</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2020">
 <h1 id="section-36">2020</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_burton">
 <h2 id="burton-1">2020/burton</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-95">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020burtonprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/burton/prog.c">2020/burton/prog.c</a></h3>
 <h3 id="information-2020burtonindex.html">Information: <a href="2020/burton/index.html">2020/burton/index.html</a></h3>
@@ -3349,9 +3671,11 @@ documented and should not be fixed (of course you may fix it to see if you can
 but it shouldn’t be made into a pull request).</p>
 <p>It will also show funny output with more than one arg. This should not be fixed
 either. But can you figure out why this happens?</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_carlini">
 <h2 id="carlini">2020/carlini</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-96">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020carliniprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/carlini/prog.c">2020/carlini/prog.c</a></h3>
 <h3 id="information-2020carliniindex.html">Information: <a href="2020/carlini/index.html">2020/carlini/index.html</a></h3>
@@ -3363,9 +3687,11 @@ lose.</p>
 <p>If a player tries to play a move they already played they will forfeit their
 move.</p>
 <p>If you have audible bells enabled the program will beep at every turn.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_ferguson1">
 <h2 id="ferguson1">2020/ferguson1</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-97">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson1/prog.c">2020/ferguson1/prog.c</a></h3>
 <h3 id="information-2020ferguson1index.html">Information: <a href="2020/ferguson1/index.html">2020/ferguson1/index.html</a></h3>
@@ -3373,18 +3699,22 @@ move.</p>
 things that are misinterpreted as bugs. See the
 <a href="2020/ferguson1/bugs.html">bugs.html</a> and
 <a href="2020/ferguson1/troubleshooting.html">troubleshooting.html</a> files for details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_giles">
 <h2 id="giles">2020/giles</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-98">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020gilesprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/giles/prog.c">2020/giles/prog.c</a></h3>
 <h3 id="information-2020gilesindex.html">Information: <a href="2020/giles/index.html">2020/giles/index.html</a></h3>
 <p>The author noted that the program only supports WAV files that have
 exactly 16 bits per sample, but it allows any sample rate and any number of
 audio channels.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2020_otterness">
 <h2 id="otterness">2020/otterness</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-inabiaf---please-do-not-fix-99">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2020otternessprog.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/otterness/prog.c">2020/otterness/prog.c</a></h3>
 <h3 id="information-2020otternessindex.html">Information: <a href="2020/otterness/index.html">2020/otterness/index.html</a></h3>
@@ -3404,31 +3734,34 @@ cause of program failures, in my experience, has been Limitation 2.</p></li>
 <p>See also the <a href="2020/otterness/index.html#program-error-codes">Program error
 codes</a> written by the author
 which lists some other conditions which should be considered features, not bugs.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2021">
 <h1 id="section-37">2021</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2021.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2022">
 <h1 id="section-38">2022</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2022.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2023">
 <h1 id="section-39">2023</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>There was no IOCCC in 2023.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2024">
 <h1 id="section-40">2024</h1>
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
-<p>We hope to run the IOCCCMOCK this year, 2024, and hopefully the next IOCCC, but
-for now we wish everyone a happy new year!</p>
+<p>We plan to run IOCCC28 this year but the time has not been announced just yet.</p>
 <h1 id="final-words">Final words</h1>
 <p>We hope this document was of use to you in determining which entries are known
 to have a problem, what entries are known to have features that are not bugs and
@@ -3437,6 +3770,7 @@ fixes] via a <a href="https://github.com/ioccc-src/winner/pulls">GitHub pull
 request</a> or otherwise, we
 thank you as well for the help! We will happily add you to the
 <a href="thanks-for-help.html">thanks</a> file as well.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Jump to: <a href="#">top</a></p>
 <!--

--- a/bugs.md
+++ b/bugs.md
@@ -14,6 +14,8 @@ below and you wish to help with a year, you can use these links:
 - [2012 entries](#2012) |       [2013 entries](#2013)   |       [2014 entries](#2014)   |       [2015 entries](#2015)
 - [2018 entries](#2018) |       [2019 entries](#2019)   |       [2020 entries](#2020)
 
+Jump to: [top](#)
+
 ## PLEASE read the next sections if you wish to help
 
 There are a number of known problems with IOCCC entries: many of
@@ -44,6 +46,7 @@ format is consistent and clean.
 
 THANK YOU!
 
+Jump to: [top](#)
 
 ## To the winning authors:
 
@@ -60,6 +63,7 @@ of times. At one point some things were changed to a bug (a usability problem
 for example) to be fixed but when looking at the index.html file it was noticed
 it was documented so the fixes were undone at that point.
 
+Jump to: [top](#)
 
 ### ON **ALL** FIXES / IMPROVEMENTS / CHANGES
 
@@ -89,6 +93,7 @@ one that's more than fine (and it has been done numerous times).
 
 Again, THANK YOU!
 
+Jump to: [top](#)
 
 <hr>
 
@@ -103,9 +108,11 @@ Entries below have one or more of the following _**STATUS**_ values. Please see
 the text below for more information. If an entry has more than one status it
 means that either they all apply or they complement each other.
 
+Jump to: [top](#)
 
 ## General notes about the statuses and making fixes
 
+Jump to: [top](#)
 
 ### Compiler warnings are very rarely a problem
 
@@ -147,6 +154,7 @@ problem but in general they should be ignored even if they're annoying.
 
 Hopefully with the example entries listed above you get the idea.
 
+Jump to: [top](#)
 
 ### General request on original code:
 
@@ -155,16 +163,19 @@ make it as close to the original but allowing it to work. This might be less of
 a problem when providing alternate versions but it might still be nice to have
 it as close as possible to the original. See also below two points.
 
+Jump to: [top](#)
 
 ### Request for one-liners:
 
-For one-liners _PLEASE KEEP THE FILE ONE LINE IF AT ALL POSSIBLE_! If it needs an
+For one-liners _PLEASE KEEP THE FILE ONE LINE IF AT ALL POSSIBLE_! See the
+[guidelines](next/guidelines.html) for what constitutes a one-liner. If it needs an
 include you can update the Makefile `CINCLUDE` variable. For instance if it
 needs `stdio.h` you could do `-include stdio.h`. Please leave a space after the
 `=` in the Makefile. You may also have extra long lines if this seems useful to
 make it a one-liner even if it kind of makes it longer than what the judges
 consider a one-liner, at least within reason. Thank you!
 
+Jump to: [top](#)
 
 ### On layout of program source:
 
@@ -179,6 +190,7 @@ that with:
     :set formatoptions=
 ```
 
+Jump to: [top](#)
 
 ## STATUS: known bug
 
@@ -192,8 +204,11 @@ where it might sometimes border on tampering with the program. And after all,
 these are not meant to be maintainable or even good programming style! Use
 careful judgement when fixing bugs please!
 
+Jump to: [top](#)
 
 ## STATUS: possible bug
+
+Jump to: [top](#)
 
 ### System dependent bug possibly
 
@@ -204,8 +219,9 @@ system.  In these entries it's unknown if there is a bug and sometimes it's
 because we do not remember and sometimes we don't have the appropriate system or
 environment to test and fix any possible problems.
 
+Jump to: [top](#)
 
-## STATUS: might not be completely functional
+### STATUS: might not be completely functional
 
 **Can you confirm there is a bug?**
 
@@ -213,8 +229,11 @@ Although these entries _appear_ to work for one or more reasons we're unsure if
 they are completely functional. Can you confirm this? Please let us know so we
 can fix it!
 
+Jump to: [top](#)
 
 ## STATUS: probable bug
+
+Jump to: [top](#)
 
 ### Possible system dependent bug
 
@@ -224,6 +243,7 @@ Entries with this status almost certainly have a bug or some other problem. The
 issue or issues might depend on the system much like the above _STATUS: possible
 bug (possibly depending on system)_.
 
+Jump to: [top](#)
 
 ## STATUS: doesn't work with some platforms
 
@@ -232,6 +252,7 @@ bug (possibly depending on system)_.
 Entries with this status do not work under some OSes and/or architectures (and/or
 something else?). Please help us to fix it!
 
+Jump to: [top](#)
 
 ## STATUS: doesn't work with some compilers
 
@@ -248,6 +269,7 @@ cases it might be better to provide alternate code anyway. Use a judgement call
 here as best you can manage.
 
 
+Jump to: [top](#)
 
 ## STATUS: main() function args not allowed
 
@@ -280,9 +302,8 @@ entries the fix was done with a new function, often called `pain()` :-)
 clang** despite the fact it might appear to be gcc: no symlink and both gcc and
 clang exist but the gcc is clang which you'll see if you run `gcc --version`.
 
-A tip and some fix methods from [Cody Boone
-Ferguson](authors.html#Cody_Boone_Ferguson): in the older days args to main()
-not given a type were implicit ints but when they're required to be `char **`
+A tip and some fix methods: in the older days args to `main()`
+not given a type were implicit `int`s but when they're required to be `char **`
 this can cause a problem. In some cases it was possible to use a `char *` inside
 `main()` (see [1989/tromp/tromp.c](%%REPO_URL%%/1989/tromp/tromp.c) and
 [1986/holloway/holloway.c](1986/holloway/index.html) for two examples though
@@ -292,6 +313,7 @@ various techniques to get these to compile. In some cases this introduced a
 problem but typically if not always that problem exists with compilers that are
 less strict.
 
+Jump to: [top](#)
 
 ## STATUS: main() has only one arg
 
@@ -306,6 +328,7 @@ At this time (04 Feb 2024) there is one entry known (it is possible that not all
 were checked) that has this problem but it's not as simple as the others to fix
 without breaking it.
 
+Jump to: [top](#)
 
 ## STATUS: compiled executable crashes
 
@@ -320,6 +343,7 @@ not mutually exclusive in some cases).
 REMINDER: if you're debugging a crash it will be very helpful to have `-O0 -g`
 or if you can `-ggdb3` when compiling as that will help with debugging symbols.
 
+Jump to: [top](#)
 
 ## STATUS: uses gets()
 
@@ -367,6 +391,7 @@ noted above).
 Sometimes `getline(3)` will work but note that this function also stores the
 newline just like `fgets(3)`.
 
+Jump to: [top](#)
 
 ## STATUS: missing file(s)
 
@@ -377,6 +402,7 @@ cases these files can be found on the [IOCCC website](https://www.ioccc.org) but
 in other cases they are entirely absent. In this case you'll probably have to
 contact the author (unless you are the author! :-) ).
 
+Jump to: [top](#)
 
 ## STATUS: missing or dead link
 
@@ -388,6 +414,7 @@ useful but there happens to be numerous links that this is not helpful. In other
 cases the URL has changed. Some of these have been discovered by the Internet
 Wayback Machine with the orange status.
 
+Jump to: [top](#)
 
 ### Statuses of Internet Wayback Machine archive:
 
@@ -397,6 +424,7 @@ Wayback Machine with the orange status.
 
 The archive website will tell you if the link was never captured.
 
+Jump to: [top](#)
 
 ## STATUS: INABIAF - please **DO NOT** fix
 ### INABIAF: It's not a bug it's a feature :-)
@@ -427,22 +455,21 @@ says it can be fixed it can be. Otherwise it should not be.
 
 Nonetheless we challenge you to fix these entries for educational/instructional
 value and/or enjoyment but we kindly request that you **DO NOT** submit a pull
-request unless it's a bug or (mis)feature we would like you to fix! If you can't
-figure it out you're invited to look at the git diffs, where there are some
-(some were fixed earlier on but rolled back as both Cody and Landon individually
-felt that the fix was tampering with the entry).
+request unless it's a bug or (mis)feature we would like you to fix!
 
 **NOTE**: in the case of `gets()` we've fixed some to avoid the warning of the
 compiler, linker or even during runtime, depending on the system. In [some cases
 like 1990/tbr](1990/tbr/index.html) the fix actually prevents confusing output (though that
 was not the only fix made in that entry).
 
+Jump to: [top](#)
 
 ### Exception: your own entries
 
 Of course if you're the author you're welcome to fix your own entry, prefer your
 own fix or suggest that they're fixed!
 
+Jump to: [top](#)
 
 <hr>
 
@@ -456,10 +483,13 @@ own fix or suggest that they're fixed!
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1984_decot">
 ## 1984/decot
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1984/decot/decot.c](%%REPO_URL%%/1984/decot/decot.c)
@@ -476,10 +506,13 @@ code. In particular you should see something like:
 
 without a newline after the `\`. This is not a bug.
 
+Jump to: [top](#)
 
 <div id="1984_laman">
 ## 1984/laman
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1984/laman/laman.c](%%REPO_URL%%/1984/laman/laman.c)
@@ -487,10 +520,13 @@ without a newline after the `\`. This is not a bug.
 
 This program will very likely crash or do something funny without an arg.
 
+Jump to: [top](#)
 
 <div id="1984_mullender">
 ## 1984/mullender
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1984/mullender/mullender.c](%%REPO_URL%%/1984/mullender/mullender.c)
@@ -509,6 +545,7 @@ produce a `short[]` that can compile in modern systems but it will not work.
 Before the fix it would fail in some cases and it is possible that in some cases
 it might still fail.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1985">
@@ -518,6 +555,7 @@ it might still fail.
 
 There are no known bugs or (mis)features for entries in 1985.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1986">
@@ -525,10 +563,13 @@ There are no known bugs or (mis)features for entries in 1985.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1986_august">
 ## 1986/august
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1986/august/august.c](%%REPO_URL%%/1986/august/august.c)
@@ -538,6 +579,7 @@ There are no known bugs or (mis)features for entries in 1985.
 This entry is known to segfault after printing its output. It was documented by
 the judges and shouldn't be fixed.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1987">
@@ -547,6 +589,7 @@ the judges and shouldn't be fixed.
 
 There are no known bugs or (mis)features for entries in 1987.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1988">
@@ -554,10 +597,13 @@ There are no known bugs or (mis)features for entries in 1987.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1988_dale">
 ## 1988/dale
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1988/dale/dale.c](%%REPO_URL%%/1988/dale/dale.c)
@@ -567,6 +613,7 @@ In linux it might happen that despite no error message or message about doing
 so, the program drops a core file into the directory even though the entry works
 and does not crash.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1989">
@@ -574,10 +621,13 @@ and does not crash.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1989_fubar">
 ## 1989/fubar
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1989/fubar/fubar.c](%%REPO_URL%%/1989/fubar/fubar.c)
@@ -588,10 +638,13 @@ details) with a number < 0 or larger than, say 20, it's very likely that the
 program will turn into an infinite loop trying to compile code and end up with
 with syntax errors. As this was documented it is not a bug to be fixed.
 
+Jump to: [top](#)
 
 <div id="1989_robison">
 ## 1989/robison
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1989/robison/robison.c](%%REPO_URL%%/1989/robison/robison.c)
@@ -603,10 +656,13 @@ numbers with non-binary digits.
 There are also other cases where this can happen for instance using unsupported
 operators like `/`. To see what operators are supported check the source code.
 
+Jump to: [top](#)
 
 <div id="1989_westley">
 ## 1989/westley
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [1989/westley/westley.c](%%REPO_URL%%/1989/westley/westley.c)
@@ -620,17 +676,27 @@ be compiled with clang. An example invocation is:
     ./ver2 < westley.c
 ```
 
+Jump to: [top](#)
+
 ### A useful note on changing/fixing this program
 
 It should be noted that in additional to rot13 names there is code that is the
-reverse of other code (also wrt names). See the source file and the index.html
-(in the author's remarks) for more details.
+reverse of other code (also with respect to names). See the source file and the
+index.html (in the author's remarks) for more details.
 
 Fixing the (mis)feature is likely to be a very difficult challenge especially
-without breaking something else which is far more likely (see below in tips from
-Cody, who fixed it so the original would compile with `clang` and at least one
-generated version would compile with `clang` too, not compromising the other
-versions with `gcc`). You are welcome to try and fix it if you can!
+without breaking something else which is far more likely (see below tips from).
+You are welcome to try and fix it if you can but unless you can get all to
+compile with `clang` **AND** `gcc`, which seems unlikely (see below), this
+should not be touched further. Nonetheless you are welcome to try and fix it if
+you can.
+
+Be aware, however, that even if you can get it to compile with both `gcc` and
+`clang`, different versions will have errors so that it's not actually a fix.
+For instance it was fixed to work for both `clang` and `gcc` but when testing
+the fix in fedora linux it failed to even compile!
+
+Jump to: [top](#)
 
 ### Tips:
 
@@ -645,6 +711,8 @@ bounds by the int `gnat`. For instance:
     (gdb) p gnat
     $1 = -518733305
 ```
+
+Jump to: [top](#)
 
 ### Magic of the entry:
 
@@ -727,6 +795,7 @@ clang but on another system and it had syntax errors.
 
 Enjoy! :-)
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1990">
@@ -734,10 +803,13 @@ Enjoy! :-)
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1990_baruch">
 ## 1990/baruch
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1990/baruch/baruch.c](%%REPO_URL%%/1990/baruch/baruch.c)
@@ -805,12 +877,15 @@ more time and resources to run as well. For instance:
     ./baruch  37496.97s user 58.50s system 99% cpu 10:27:48.29 total
 ```
 
-This is not considered a bug, however.
+This is a feature, not a bug!
 
+Jump to: [top](#)
 
 <div id="1990_jaw">
 ## 1990/jaw
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [1990/jaw/jaw.c](%%REPO_URL%%/1990/jaw/jaw.c)
@@ -849,9 +924,7 @@ If one does, however:
 
 they will get just
 
-```
-    oops
-```
+> oops
 
 which seems to be an error message (one of the fixes was to make it not use
 `perror(3)` - this fixed something else though it's no longer known what except
@@ -864,10 +937,13 @@ wanting to accept reading from `stdin` (this in particular) even with the right
 options used, seemingly, it has to write to disk the tarball which seems to
 defeat the purpose. This would ideally be fixed.
 
+Jump to: [top](#)
 
 <div id="1990_tbr">
 ## 1990/tbr
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1990/tbr/tbr.c](%%REPO_URL%%/1990/tbr/tbr.c)
@@ -876,10 +952,13 @@ defeat the purpose. This would ideally be fixed.
 The authors provided a list of features in the
 [BUGS](1990/tbr/index.html#bugs) section in their remarks.
 
+Jump to: [top](#)
 
 <div id="1990_theorem">
 ## 1990/theorem
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1990/theorem/theorem.c](%%REPO_URL%%/1990/theorem/theorem.c)
@@ -891,10 +970,13 @@ fixed but one thing to note is that if you pass two zeroes to `theorem_bkp` or
 again; another condition where this occurred was fixed but this one should not
 be fixed.
 
+Jump to: [top](#)
 
 <div id="1990_westley">
 ## 1990/westley
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1990/westley/westley.c](%%REPO_URL%%/1990/westley/westley.c)
@@ -908,6 +990,7 @@ maybe, to change it back, especially as it is annoying to have the screen
 flooded).
 
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1991">
@@ -915,10 +998,13 @@ flooded).
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1991_buzzard">
 ## 1991/buzzard
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1991/buzzard/buzzard.c](%%REPO_URL%%/1991/buzzard/buzzard.c)
@@ -930,10 +1016,13 @@ file does not exist in the directory, this program will very likely crash.
 
 This is a feature, not a bug.
 
+Jump to: [top](#)
 
 <div id="1991_westley">
 ## 1991/westley
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1991/westley/westley.c](%%REPO_URL%%/1991/westley/westley.c)
@@ -947,6 +1036,7 @@ Please don't try and fix it as it's not a bug and was actually documented as a
 possibility. Can you find out how? There's also a way to make it so that even
 when you're cheating it ends up winning! Can you figure that out as well?
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1992">
@@ -954,11 +1044,13 @@ when you're cheating it ends up winning! Can you figure that out as well?
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1992_adrian">
 ## 1992/adrian
 </div>
 
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1992/adrian/adrian.c](%%REPO_URL%%/1992/adrian/adrian.c)
@@ -987,11 +1079,13 @@ changed either even if it appears to be wrong. Notice too a curious thing: if
 you did change it to `fprintf()`, even if you have the right number of args, you'd
 have to remove the outer `()` pair.
 
+Jump to: [top](#)
 
 <div id="1992_albert">
 ## 1992/albert
 </div>
 
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [1992/albert/albert.c](%%REPO_URL%%/1992/albert/albert.c)
@@ -1054,10 +1148,13 @@ condition.
 The alt version does fix the problem but it is not obfuscated and not like the
 entry itself. Can you fix the actual entry? You are welcome to try and do so.
 
+Jump to: [top](#)
 
 <div id="1992_gson">
 ## 1992/gson
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: uses gets() - change to fgets() if possible
 ### Source code: [1992/gson/gson.c](%%REPO_URL%%/1992/gson/gson.c)
@@ -1072,6 +1169,7 @@ which can be described simply as: first `m` is set to `*++p` in a for loop where
 is called as `m = gets(m)`) but trying to change it to use `fgets(3)` breaks the
 program.
 
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 
@@ -1090,10 +1188,13 @@ less.
 ... so whether or not the `gets(3)` should be changed to `fgets(3)` is up to
 debate.
 
+Jump to: [top](#)
 
 <div id="1992_kivinen">
 ## 1992/kivinen
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [1992/kivinen/kivinen.c](%%REPO_URL%%/1992/kivinen/kivinen.c)
@@ -1103,12 +1204,13 @@ When you start the program everything starts to move over to the right side and
 then ends. [Yusuke Endoh](authors.html#Yusuke_Endoh) pointed out that if you
 click the mouse it takes it back towards the centre.
 
-If you want to try and fix this, you are welcome to try.
-
+Jump to: [top](#)
 
 <div id="1992_lush">
 ## 1992/lush
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: doesn't work with some compilers - please provide alternative code or fix for more compilers
 ### Source code: [1992/lush/lush.c](%%REPO_URL%%/1992/lush/lush.c)
@@ -1122,7 +1224,7 @@ Unfortunately due to the way the entry works and the fact that other compilers
 like clang have different warnings and errors this simply does not work with
 them.
 
-Some tips:
+#### Some tips:
 
 This entry relies on specific compiler warnings. With gcc it will look something
 like:
@@ -1188,12 +1290,13 @@ The entry is supposed to show warnings and then print:
     Hello World.
 ```
 
-Can you help us?
-
+Jump to: [top](#)
 
 <div id="1992_vern">
 ## 1992/vern
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1992/vern/vern.c](%%REPO_URL%%/1992/vern/vern.c)
@@ -1203,10 +1306,13 @@ When your own checkmate is imminent it prints `"Har har"` but does not exit so
 it can '_rub your nose in defeat_', as the author puts it. You will have to exit
 it yourself through ctrl-c or killing it in some other fashion.
 
+Jump to: [top](#)
 
 <div id="1992_westley">
 ## 1992/westley
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1992/westley/westley.c](%%REPO_URL%%/1992/westley/westley.c)
@@ -1222,6 +1328,7 @@ terminal try:
     echo $COLUMNS
 ```
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1993">
@@ -1229,10 +1336,13 @@ terminal try:
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1993_ant">
 ## 1993/ant
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1993/ant/ant.c](%%REPO_URL%%/1993/ant/ant.c)
@@ -1247,10 +1357,13 @@ The author stated that:
 > There is no check for unbalanced brackets.  Omitting a closing bracket will
 generate a "Pattern too long" error, which is not the real error.
 
+Jump to: [top](#)
 
 <div id="1993_cmills">
 ## 1993/cmills
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [1993/cmills/cmills.c](%%REPO_URL%%/1993/cmills/cmills.c)
@@ -1259,12 +1372,13 @@ generate a "Pattern too long" error, which is not the real error.
 In multiple platforms, both macOS and also linux (in particular a RHEL 9.3
 system), this entry just shows a blank screen.
 
-Can you fix it? We welcome your help.
-
+Jump to: [top](#)
 
 <div id="1993_lmfjyh">
 ## 1993/lmfjyh
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1993/lmfjyh/lmfjyh.c](%%REPO_URL%%/1993/lmfjyh/lmfjyh.c)
@@ -1276,10 +1390,13 @@ cannot be fixed for modern systems as the bug is long gone.
 An alternate version that will work for modern systems, however, does exist. See
 the index.html file for details.
 
+Jump to: [top](#)
 
 <div id="1993_rince">
 ## 1993/rince
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1993/rince/rince.c](%%REPO_URL%%/1993/rince/rince.c)
@@ -1291,10 +1408,13 @@ will cause problems. No other checks are performed either.
 There is no end of game checking function so you will have to quit the game
 through ctrl-c or such.
 
+Jump to: [top](#)
 
 <div id="1993_schnitzi">
 ## 1993/schnitzi
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1993/schnitzi/schnitzi.c](%%REPO_URL%%/1993/schnitzi/schnitzi.c)
@@ -1336,12 +1456,15 @@ Of course if you do something like:
     What is 'foo'?
 ```
 
-it will work fine.
+it will work fine. This is a feature, not a bug!
 
+Jump to: [top](#)
 
 <div id="1993_vanb">
 ## 1993/vanb
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1993/vanb/vanb.c](%%REPO_URL%%/1993/vanb/vanb.c)
@@ -1355,6 +1478,7 @@ spurious results.
 The unary `-` is an operator so decimal `-46` should be entered as `-d46` and
 not `d-46`.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1994">
@@ -1362,10 +1486,13 @@ not `d-46`.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1994_dodsond2">
 ## 1994/dodsond2
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1994/dodsond2/dodsond2.c](%%REPO_URL%%/1994/dodsond2/dodsond2.c)
@@ -1378,10 +1505,13 @@ Also, when you shoot it will move you to that room so if you end up shooting
 into a pit room you will end up dying even though you didn't explicitly move
 there.
 
+Jump to: [top](#)
 
 <div id="1994_ldb">
 ## 1994/ldb
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1994/ldb/ldb.c](%%REPO_URL%%/1994/ldb/ldb.c)
@@ -1405,10 +1535,13 @@ See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for more information on the change to `fgets(3)`.
 
+Jump to: [top](#)
 
 <div id="1994_schnitzi">
 ## 1994/schnitzi
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: uses gets() - change to fgets() if possible
 ### Source code: [1994/schnitzi/schnitzi.c](%%REPO_URL%%/1994/schnitzi/schnitzi.c)
@@ -1450,6 +1583,7 @@ help to understand how it works, in case one wishes to try and fix it.
 
 For the alternate versions the other functionality is unaffected.
 
+Jump to: [top](#)
 
 ### The magic of [1994/schnitzi](1994/schnitzi/index.html) and how it flips text
 
@@ -1508,6 +1642,8 @@ provide the correct input in comments or possibly by rearranging some of the
 code (this was actually required to make the generated code compile at all when
 changing the buffer size, see below).
 
+Jump to: [top](#)
+
 ### Important points:
 
 Getting this entry to use `fgets(3)` is easy but the problem is you're supposed
@@ -1528,10 +1664,13 @@ can cause a compilation error! Make sure that the output of:
 can be compiled and the output of that new program when fed itself can also be
 compiled!
 
+Jump to: [top](#)
 
 <div id="1994_shapiro">
 ## 1994/shapiro
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1994/shapiro/shapiro.c](%%REPO_URL%%/1994/shapiro/shapiro.c)
@@ -1539,6 +1678,8 @@ compiled!
 
 This program will likely crash if the source code file (by the name of the file
 that's compiled) cannot be opened in the directory it is run from.
+
+Jump to: [top](#)
 
 ### Important reminder and a note about the `-1` value check for `getc()`:
 
@@ -1559,6 +1700,7 @@ if it checked for `!= EOF`.
 
 Since it works there is no need to fix this except for a challenge to yourself.
 
+Jump to: [top](#)
 
 ### STATUS: missing file - please provide it
 
@@ -1566,14 +1708,13 @@ The index.html file refers to an alternate version of the code that is not
 obfuscated but it is missing from the entry directory and the archive. Do you
 have this file?
 
-We would be grateful if you could provide it to us.  If you can provide this
-file you might consider removing this status from this file as well but if not
-we'll take care of it.
-
+Jump to: [top](#)
 
 <div id="1994_tvr">
 ## 1994/tvr
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1994/tvr/tvr.c](%%REPO_URL%%/1994/tvr/tvr.c)
@@ -1591,6 +1732,7 @@ However, the author stated that this is a feature so this should not be fixed.
 See also the other [bugs](1994/tvr/index.html#bugs) the author mentioned that,
 as documented, are considered features.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1995">
@@ -1598,10 +1740,13 @@ as documented, are considered features.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1995_cdua">
 ## 1995/cdua
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1995/cdua/cdua.c](%%REPO_URL%%/1995/cdua/cdua.c)
@@ -1616,10 +1761,13 @@ the code it can clearly be seen that if `g - a` is 0 then the message is
 supposed to be printed again and one is supposed to press a key as at that point
 it calls `getchar()` via the pointer `m`. So this is a feature not a bug.
 
+Jump to: [top](#)
 
 <div id="1995_leo">
 ## 1995/leo
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [1995/leo/leo.c](%%REPO_URL%%/1995/leo/leo.c)
@@ -1648,10 +1796,13 @@ first) as it appears to just block.
 It is not known if this is platform specific but this was observed in macOS and
 it would be good if it was fixed.
 
+Jump to: [top](#)
 
 <div id="1995_savastio">
 ## 1995/savastio
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1995/savastio/savastio.c](%%REPO_URL%%/1995/savastio/savastio.c)
@@ -1660,10 +1811,13 @@ it would be good if it was fixed.
 This program expects a POSITIVE number. If you specify a negative number it will
 not show any output, stuck in a loop.
 
+Jump to: [top](#)
 
 <div id="1995_vanschnitz">
 ## 1995/vanschnitz
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: missing file - please provide it
 ### Source code: [1995/vanschnitz/vanschnitz.c](%%REPO_URL%%/1995/vanschnitz/vanschnitz.c)
@@ -1672,8 +1826,7 @@ not show any output, stuck in a loop.
 The authors stated that they included a version that allows people with just K&R
 compilers to use the program but this file is missing. Can you provide it?
 
-We would appreciate anyone who has it or even just knows the name! Thank you.
-
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1996">
@@ -1681,10 +1834,13 @@ We would appreciate anyone who has it or even just knows the name! Thank you.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="1996_gandalf">
 ## 1996/gandalf
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: missing or dead link or links - please provide it or them
 ### Source code: [1996/gandalf/gandalf.c](%%REPO_URL%%/1996/gandalf/gandalf.c)
@@ -1695,10 +1851,13 @@ it was instead requiring a login / password.
 
 Do you have an updated link? We welcome your help!
 
+Jump to: [top](#)
 
 <div id="1996_huffman">
 ## 1996/huffman
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: uses gets() - change to fgets() if possible
 ### Source code: [1996/huffman/huffman.c](%%REPO_URL%%/1996/huffman/huffman.c)
@@ -1738,10 +1897,13 @@ This diff almost does it but not quite:
 But since it does not for the time being it is advisable to just redirect
 `stderr` to `/dev/null` (`2>/dev/null`).
 
+Jump to: [top](#)
 
 <div id="1996_jonth">
 ## 1996/jonth
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1996/jonth/jonth.c](%%REPO_URL%%/1996/jonth/jonth.c)
@@ -1753,6 +1915,7 @@ This should NOT be fixed.
 **NOTE**: the two boards will be on top of each other so you will have to drag one
 off the other so that you can properly play.
 
+Jump to: [top](#)
 
 ### STATUS: missing or dead link or links - please provide it or them
 
@@ -1760,6 +1923,7 @@ As well: the link which was `http://www.uio.no/~jonth` is no longer valid and
 there's no archive on the Internet Wayback Machine. Do you know of a proper URL?
 We greatly appreciate your help here!
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1997">
@@ -1769,6 +1933,7 @@ We greatly appreciate your help here!
 
 There was no IOCCC in 1997.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1998">
@@ -1776,9 +1941,13 @@ There was no IOCCC in 1997.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
+
 <div id="1998_chaos">
 ## 1998/chaos
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1998/chaos/chaos.c](%%REPO_URL%%/1998/chaos/chaos.c)
@@ -1793,7 +1962,6 @@ one block is ever allocated, and the OS should recover it.
 from `main()`.  Feh, what does it know?  Otherwise, ignoring lint's over
 protectiveness ("Of course I'm not using all of the functions defined in
 `curses.h`!"), it's lint clean.
->
 >
 > If the compiler happens to generate the byte sequence "AlWuzEre" in the
 executable by chance, the program may be unable to locate the embedded string.
@@ -1811,11 +1979,14 @@ core is a popular result.)
 from the rear) looks really odd.  And it sometimes hangs.  So just don't fly
 through objects.  You'll be happier.
 
+Jump to: [top](#)
 
 
 <div id="1998_dlowe">
 ## 1998/dlowe
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: missing or dead link or links - please provide it or them
 ### Source code: [1998/dlowe/dlowe.c](%%REPO_URL%%/1998/dlowe/dlowe.c)
@@ -1828,10 +1999,13 @@ would like to set it up?  We'll gladly thank you in the [thanks
 file](thanks-for-help.html) file and link to the page as well!  You'll also have
 IOCCC fame for reviving a pootifier! :-)
 
+Jump to: [top](#)
 
 <div id="1998_dloweneil">
 ## 1998/dloweneil
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: missing or dead link or links - please provide it or them
 ### Source code: [1998/dloweneil/dloweneil.c](%%REPO_URL%%/1998/dloweneil/dloweneil.c)
@@ -1845,11 +2019,14 @@ file](thanks-for-help.html) file and link to the page as well!  You'll also have
 IOCCC fame for reviving a pootifier! :-)
 
 
+Jump to: [top](#)
 
 
 <div id="1998_schnitzi">
 ## 1998/schnitzi
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [1998/schnitzi/schnitzi.c](%%REPO_URL%%/1998/schnitzi/schnitzi.c)
@@ -1871,6 +2048,7 @@ If you use the generated program and do not give enough numbers in input
 something funny will happen, very possibly with different results per run. This
 is in the index.html file as something to try and ponder.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="1999">
@@ -1880,6 +2058,7 @@ is in the index.html file as something to try and ponder.
 
 There was no IOCCC in 1999.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2000">
@@ -1887,11 +2066,13 @@ There was no IOCCC in 1999.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2000_dlowe">
 ## 2000/dlowe
 </div>
 
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [2000/dlowe/dlowe.c](%%REPO_URL%%/2000/dlowe/dlowe.c)
@@ -1942,7 +2123,7 @@ Okay so now it sees it, `grep`. But watch!
     $ cat foo
 ```
 
-.. so at this hour it does appear to be writing to stdout but yet somehow it doesn't? But watch:
+.. so it does appear to be writing to stdout but yet somehow it doesn't? But watch:
 
 ``` <!---sh-->
     $ echo "7 P 6 d P P 8 p" | ./dlowe 1>foo 1>&1
@@ -2097,6 +2278,7 @@ on the stack at that point:
 
 which might (?) suggest that the `+` operator is unimplemented.
 
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 
@@ -2153,11 +2335,14 @@ likely print different warnings when compiling. It was observed that with
 Homebrew it does not report any warnings but with MacPorts it results in a total
 of 92 warnings! Nonetheless neither works okay and both crash.
 
+Jump to: [top](#)
 
 
 <div id="2000_primenum">
 ## 2000/primenum
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2000/primenum/primenum.c](%%REPO_URL%%/2000/primenum/primenum.c)
@@ -2182,10 +2367,13 @@ try to fix the crashing of this code except to challenge yourself (if you think
 that it'll be worth your two second fix :-) ).  If you do fix it please do not
 make a pull request.
 
+Jump to: [top](#)
 
 <div id="2000_rince">
 ## 2000/rince
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2000/rince/rince.c](%%REPO_URL%%/2000/rince/rince.c)
@@ -2195,6 +2383,7 @@ If `DISPLAY` is not set the program will very likely crash, do something strange
 (or if you're very unlucky your computer might [halt and catch
 fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_&lpar;computing&rpar;)! :-) ).
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2001">
@@ -2202,10 +2391,13 @@ fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_&lpar;computing&rpar;)! 
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2001_anonymous">
 ## 2001/anonymous
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/anonymous/anonymous.c](%%REPO_URL%%/2001/anonymous/anonymous.c)
@@ -2226,12 +2418,16 @@ be correct).
 
 Note also that if you don't specify a file or you specify a non-32-bit ELF file
 this program will very likely crash or do something strange like slaughter the
-elves of Imladris :-(
+[Elves](https://www.glyphweb.com/arda/e/elves.html) of
+[Imladris](https://www.glyphweb.com/arda/i/imladris.php) :-(
 
+Jump to: [top](#)
 
 <div id="2001_bellard">
 ## 2001/bellard
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/bellard/bellard.c](%%REPO_URL%%/2001/bellard/bellard.c)
@@ -2265,6 +2461,7 @@ looking at the code it hard codes paths that are i386 specific to linux.
 Another point of interest is that the author provided unobfuscated versions
 which might be of value to look at.
 
+Jump to: [top](#)
 
 #### Aside: why were there changes made if INABIAF ?
 
@@ -2279,10 +2476,13 @@ Also the supplementary program, which did not work at all, was fixed and it can
 be run by itself for fun in modern systems, which was not possible before the
 fixes there.
 
+Jump to: [top](#)
 
 <div id="2001_cheong">
 ## 2001/cheong
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/cheong/cheong.c](%%REPO_URL%%/2001/cheong/cheong.c)
@@ -2290,10 +2490,13 @@ fixes there.
 
 This program will crash without an arg.
 
+Jump to: [top](#)
 
 <div id="2001_dgbeards">
 ## 2001/dgbeards
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/dgbeards/dgbeards.c](%%REPO_URL%%/2001/dgbeards/dgbeards.c)
@@ -2301,10 +2504,13 @@ This program will crash without an arg.
 
 This program deliberately crashes if it loses (which is what it aims to do).
 
+Jump to: [top](#)
 
 <div id="2001_herrmann1">
 ## 2001/herrmann1
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: missing files - please provide them
 ### Source code: [2001/herrmann1/herrmann1.c](%%REPO_URL%%/2001/herrmann1/herrmann1.c)
@@ -2313,6 +2519,7 @@ This program deliberately crashes if it loses (which is what it aims to do).
 The author referred to the file `herrmann1.turing` but it does not exist not even
 in the archive. Do you have a copy? Please provide it!
 
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 
@@ -2321,12 +2528,13 @@ animation but this does not seem to work with modern gcc versions. It appears
 that version 2.95 works but maybe others do as well. Do you have a fix? We would
 appreciate your help!
 
-If you want to try and fix this, you are welcome to try.
-
+Jump to: [top](#)
 
 <div id="2001_kev">
 ## 2001/kev
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/kev/kev.c](%%REPO_URL%%/2001/kev/kev.c)
@@ -2350,10 +2558,13 @@ points.
 Although it is independent of endianness both systems need the same character
 set. In other words both have to be ASCII or EBCDIC - not one of each.
 
+Jump to: [top](#)
 
 <div id="2001_ollinger">
 ## 2001/ollinger
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/ollinger/ollinger.c](%%REPO_URL%%/2001/ollinger/ollinger.c)
@@ -2362,10 +2573,13 @@ set. In other words both have to be ASCII or EBCDIC - not one of each.
 This program will very likely crash or do something unexpected if you do not
 provide enough args.
 
+Jump to: [top](#)
 
 <div id="2001_rosten">
 ## 2001/rosten
 </div>
+
+Jump to: [top](#)
 
 
 ### STATUS: INABIAF - please **DO NOT** fix
@@ -2374,17 +2588,20 @@ provide enough args.
 
 See list of bugs [here](2001/rosten/index.html#bugs).
 
+Jump to: [top](#)
 
 ### STATUS: missing files - please provide them
 
 The author stated that there is a cat man page for this program in case one
 wanted to install it as a tool but this is missing.
 
+Jump to: [top](#)
 
 <div id="2001_schweikh">
 ## 2001/schweikh
 </div>
 
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2001/schweikh/schweikh.c](%%REPO_URL%%/2001/schweikh/schweikh.c)
@@ -2397,11 +2614,13 @@ There's also no way to escape meta characters.
 
 See also the author's list of bugs [here](2001/schweikh/index.html#bugs).
 
+Jump to: [top](#)
 
 <div id="2001_westley">
 ## 2001/westley
 </div>
 
+Jump to: [top](#)
 
 ### STATUS: uses gets() - change to fgets() if possible
 ### Source code: [2001/westley/westley.c](%%REPO_URL%%/2001/westley/westley.c)
@@ -2410,6 +2629,7 @@ See also the author's list of bugs [here](2001/schweikh/index.html#bugs).
 This function uses `gets(3)` but it would be ideal if it used `fgets(3)`. This
 one is rather complicated but you are welcome to try and fix this if you wish.
 
+Jump to: [top](#)
 
 ### STATUS: main() has only one arg - try and make it have 2 or 3
 
@@ -2424,17 +2644,20 @@ first so that you can compare the output. Make sure to recreate the extra files
 as described by the author if you do fix this. This might be looked at later if
 nobody else takes up the challenge.
 
+Jump to: [top](#)
 
 ### STATUS: missing files - please provide them
 
 The author referred to a file `card.gif` but this file is missing. Do you have
 it? Please provide it!
 
+Jump to: [top](#)
 
 <div id="2001_williams">
 ## 2001/williams
 </div>
 
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [2001/williams/williams.c](%%REPO_URL%%/2001/williams/williams.c)
@@ -2495,6 +2718,7 @@ when the missiles come down. The fact you can shoot after it starts that
 sleeping in a loop does suggest that it's not stuck only showing those lines and
 sleeping.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2002">
@@ -2504,6 +2728,7 @@ sleeping.
 
 There was no IOCCC in 2002.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2003">
@@ -2513,6 +2738,7 @@ There was no IOCCC in 2002.
 
 There was no IOCCC in 2003.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2004">
@@ -2520,10 +2746,13 @@ There was no IOCCC in 2003.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2004_gavin">
 ## 2004/gavin
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2004/gavin/gavin.c](%%REPO_URL%%/2004/gavin/gavin.c)
@@ -2550,6 +2779,7 @@ When trying to link `gavin.o` to produce `sh`, the linker generates:
     ld: symbol(s) not found for architecture arm64
 ```
 
+Jump to: [top](#)
 
 #### Recent 2004/gavin mods:
 
@@ -2635,9 +2865,13 @@ Please also see [known features in the
 index.html](2004/gavin/index.html#known-features) for things that are not bugs
 but documented (mis)features.
 
+Jump to: [top](#)
+
 <div id="2004_hibachi">
 ## 2004/hibachi
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2004/hibachi/hibachi.c](%%REPO_URL%%/2004/hibachi/hibachi.c)
@@ -2648,12 +2882,15 @@ The author stated that:
 > The links (text) web browser does not support RFC 2616 section 7.2.1 paragraph 3
 sentence 2, and so fails to display responses from `hibachi`.
 
+Jump to: [top](#)
 
 
 
 <div id="2004_jdalbec">
 ## 2004/jdalbec
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2004/jdalbec/jdalbec.c](%%REPO_URL%%/2004/jdalbec/jdalbec.c)
@@ -2677,10 +2914,13 @@ runs of the same symbol.
 results (e.g., generation 1 starting from a string of 257 `1`s will be
 calculated as `11`); the remark from the previous paragraph applies here also.
 
+Jump to: [top](#)
 
 <div id="2004_sds">
 ## 2004/sds
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2004/sds/sds.c](%%REPO_URL%%/2004/sds/sds.c)
@@ -2689,6 +2929,7 @@ calculated as `11`); the remark from the previous paragraph applies here also.
 The generated code will very likely segfault or do something not intended if not
 given the right args. See the index.html file for the correct syntax.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2005">
@@ -2696,10 +2937,13 @@ given the right args. See the index.html file for the correct syntax.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2005_anon">
 ## 2005/anon
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2005/anon/anon.c](%%REPO_URL%%/2005/anon/anon.c)
@@ -2715,10 +2959,13 @@ If you specify more than three args the program might also crash or do something
 strange. This might also happen if you specify excessively large board
 dimensions. Try `100 100 100` for instance and see what happens!
 
+Jump to: [top](#)
 
 <div id="2005_giljade">
 ## 2005/giljade
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2005/giljade/giljade.c](%%REPO_URL%%/2005/giljade/giljade.c)
@@ -2732,10 +2979,14 @@ sizeof(FILE *)`.
 
 This entry requires that `sed` and `make` are in your `$PATH`.
 
+Jump to: [top](#)
 
 <div id="2005_mikeash">
 ## 2005/mikeash
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2005/mikeash/mikeash.c](%%REPO_URL%%/2005/mikeash/mikeash.c)
@@ -2780,10 +3031,14 @@ nowhere near
 > Basically, the LISP interpreter is good for some basic math operations, and
 for running itself.
 
+Jump to: [top](#)
 
 <div id="2005_mynx">
 ## 2005/mynx
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2005/mynx/mynx.c](%%REPO_URL%%/2005/mynx/mynx.c)
@@ -2798,10 +3053,14 @@ pointing out as it won't work on as many websites as it used to including the
 [IOCCC website](https://www.ioccc.org) itself. The author noted that someone did
 make a version that supports `https` but it is not known where this might be.
 
+Jump to: [top](#)
+
 
 <div id="2005_sykes">
 ## 2005/sykes
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2005/sykes/sykes.c](%%REPO_URL%%/2005/sykes/sykes.c)
@@ -2832,6 +3091,7 @@ The
 [emulation](https://en.wikipedia.org/wiki/Emulator) does not include the seldom
 used decimal mode, or any of the "undocumented" instructions.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2006">
@@ -2839,10 +3099,14 @@ used decimal mode, or any of the "undocumented" instructions.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2006_birken">
 ## 2006/birken
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: uses gets() - change to fgets() if possible
 ### Source code: [2006/birken/birken.c](%%REPO_URL%%/2006/birken/birken.c)
@@ -2858,10 +3122,14 @@ with at least `computer.tofu` input file:
     #define gets(c) fgets((c),PI,stdin)&&(((c)[strlen((c))-1]='\0'),c!=NULL)
 ```
 
+Jump to: [top](#)
 
 <div id="2006_borsanyi">
 ## 2006/borsanyi
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2006/borsanyi/borsanyi.c](%%REPO_URL%%/2006/borsanyi/borsanyi.c)
@@ -2871,10 +3139,14 @@ The string specified must be <= 42 characters and may only consist of the
 characters in the regex `a-z_A-Z0-9@.-`. Breaking these constraints will end up
 with possibly corrupt GIF files.
 
+Jump to: [top](#)
 
 <div id="2006_hamre">
 ## 2006/hamre
 </div>
+
+Jump to: [top](#)
+
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2006/hamre/hamre.c](%%REPO_URL%%/2006/hamre/hamre.c)
@@ -2882,10 +3154,13 @@ with possibly corrupt GIF files.
 
 This program will likely crash or do something funny without an arg.
 
+Jump to: [top](#)
 
 <div id="2006_monge">
 ## 2006/monge
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: doesn't work with some platforms - please help us fix it
 ### Source code: [2006/monge/monge.c](%%REPO_URL%%/2006/monge/monge.c)
@@ -2903,6 +3178,7 @@ provide it as an additional alt version. Fixing this is very likely to be very
 challenging and in some systems it will not be possible to fix but you are
 welcome to try and fix it if you wish to!
 
+Jump to: [top](#)
 
 
 
@@ -2910,10 +3186,14 @@ welcome to try and fix it if you wish to!
 
 Incorrect formulas will ungracefully crash the program.
 
+Jump to: [top](#)
 
 <div id="2006_stewart">
 ## 2006/stewart
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2006/stewart/stewart.c](%%REPO_URL%%/2006/stewart/stewart.c)
@@ -2922,10 +3202,14 @@ Incorrect formulas will ungracefully crash the program.
 This program will likely crash or do something funny if the file cannot be
 opened. The number of args is however checked.
 
+Jump to: [top](#)
 
 <div id="2006_sykes1">
 ## 2006/sykes1
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2006/sykes1/sykes1.c](%%REPO_URL%%/2006/sykes1/sykes1.c)
@@ -2943,10 +3227,14 @@ result in the 19186 unique solutions.
 >    If you pick a number higher than 460464 (24x19186) the program will return
 without outputting a solution.  If you can wait that long.
 
+Jump to: [top](#)
 
 <div id="2006_toledo2">
 ## 2006/toledo2
 </div>
+
+
+Jump to: [top](#)
 
 
 ### STATUS: INABIAF - please **DO NOT** fix
@@ -2969,6 +3257,7 @@ be called a bug :-)
 You must type in caps (except in strings) and this program is indeed
 case-sensitive.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2007">
@@ -2979,6 +3268,8 @@ case-sensitive.
 There was no IOCCC in 2007.
 
 
+Jump to: [top](#)
+
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2008">
 # 2008
@@ -2988,6 +3279,8 @@ There was no IOCCC in 2007.
 There was no IOCCC in 2008.
 
 
+Jump to: [top](#)
+
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2009">
 # 2009
@@ -2996,6 +3289,7 @@ There was no IOCCC in 2008.
 
 There was no IOCCC in 2009.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2010">
@@ -3006,16 +3300,21 @@ There was no IOCCC in 2009.
 There was no IOCCC in 2010.
 
 
+Jump to: [top](#)
+
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2011">
 # 2011
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2011_borsanyi">
 ## 2011/borsanyi
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2011/borsanyi/borsanyi.c](%%REPO_URL%%/2011/borsanyi/borsanyi.c)
@@ -3039,10 +3338,14 @@ available stack space.
 - Rounding errors might cause an omission in the highest bin. There might be
 empty bins at the edges.
 
+Jump to: [top](#)
 
 <div id="2011_dlowe">
 ## 2011/dlowe
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: missing or dead link or links - please provide it or them
 ### Source code: [2011/dlowe/dlowe.c](%%REPO_URL%%/2011/dlowe/dlowe.c)
@@ -3056,6 +3359,7 @@ file](thanks-for-help.html) file and link to the page as well!  You'll also have
 IOCCC fame for reviving a pootifier! :-)
 
 
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 
@@ -3071,10 +3375,13 @@ tends to result in empty output.
 * Will crash and die horribly if it runs out of memory.
 
 
+Jump to: [top](#)
 
 <div id="2011_fredriksson">
 ## 2011/fredriksson
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2011/fredriksson/fredriksson.c](%%REPO_URL%%/2011/fredriksson/fredriksson.c)
@@ -3085,10 +3392,13 @@ list is rather long see [other
 features](2011/fredriksson/index.html#other-features) and [limitations and
 remarks](2011/fredriksson/index.html#limitations-and-remarks) instead.
 
+Jump to: [top](#)
 
 <div id="2011_konno">
 ## 2011/konno
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2011/konno/konno.c](%%REPO_URL%%/2011/konno/konno.c)
@@ -3097,6 +3407,7 @@ remarks](2011/fredriksson/index.html#limitations-and-remarks) instead.
 This program will very likely crash or do something funny without an arg.
 
 
+Jump to: [top](#)
 
 <div id="2011_richards">
 ## 2011/richards
@@ -3120,6 +3431,7 @@ author as well as some resources on Apple's website should anyone wish to take a
 crack at it. A starting point might be in
 [richards.alt.c](%%REPO_URL%%/2011/richards/richards.alt.c).
 
+Jump to: [top](#)
 
 ### Debugging
 
@@ -3154,7 +3466,7 @@ so it would appear that
     x[(u)c]
 ```
 
-(at least in my tired head?) is NULL. But why does it work then?
+is NULL. But why does it work then?
 
 **NOTE**: `u` is `int`.
 
@@ -3285,19 +3597,25 @@ A warning of interest when compiling is:
 This can be fixed easily enough however but it doesn't appear to matter in this
 case.
 
+Jump to: [top](#)
 
 ### Testing fixes
 
 It might be helpful to use the [try.alt.sh](%%REPO_URL%%/2011/richards/try.alt.sh) script to
 test that it does not crash and functions properly.
 
+Jump to: [top](#)
 
 ### Resources
+
+Jump to: [top](#)
 
 #### More from the author
 
 The author has more about the entry at
 <https://github.com/GregorR/ioccc2011>.
+
+Jump to: [top](#)
 
 #### Apple resources
 
@@ -3315,12 +3633,13 @@ CONFIG_DYNAMIC_CODE_SIGNING` and the protection variable has the
 unconfirmed and it's not known when `CONFIG_DYNAMIC_CODE_SIGNING` would be
 defined.
 
-Do you have a fix? We welcome it!
-
+Jump to: [top](#)
 
 <div id="2011_vik">
 ## 2011/vik
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2011/vik/vik.c](%%REPO_URL%%/2011/vik/vik.c)
@@ -3330,6 +3649,7 @@ The author stated that the program will crash if no argument is passed to the
 program though we note that your computer might also [halt and catch
 fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_&lpar;computing&rpar;) :-)
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2012">
@@ -3337,10 +3657,13 @@ fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_&lpar;computing&rpar;) :
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2012_blakely">
 ## 2012/blakely
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2012/blakely/blakely.c](%%REPO_URL%%/2012/blakely/blakely.c)
@@ -3351,10 +3674,13 @@ The author stated:
 > If there is a division by zero, square-root of a negative number, or similar
 operation, then the results are undefined.
 
+Jump to: [top](#)
 
 <div id="2012_deckmyn">
 ## 2012/deckmyn
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2012/deckmyn/deckmyn.c](%%REPO_URL%%/2012/deckmyn/deckmyn.c)
@@ -3391,10 +3717,13 @@ musical element of a line is only 2 characters!
 
 The manual referred to is [here](2012/deckmyn/deckmyn.html).
 
+Jump to: [top](#)
 
 <div id="2012_dlowe">
 ## 2012/dlowe
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2012/dlowe/dlowe.c](%%REPO_URL%%/2012/dlowe/dlowe.c)
@@ -3408,10 +3737,13 @@ The author stated:
   `dead.d` and `sprites.d`).
 * Cannot build or run without X11 (or an X11 compatibility layer).
 
+Jump to: [top](#)
 
 <div id="2012_tromp">
 ## 2012/tromp
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2012/tromp/tromp.c](%%REPO_URL%%/2012/tromp/tromp.c)
@@ -3434,10 +3766,13 @@ interpreter to crash when looking into a null-pointer environment:
 >
 > will likely dump core.
 
+Jump to: [top](#)
 
 <div id="2012_vik">
 ## 2012/vik
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2012/vik/vik.c](%%REPO_URL%%/2012/vik/vik.c)
@@ -3449,6 +3784,7 @@ mismatching sizes or unsupported pixel formats though we note that your computer
 might also [halt and catch
 fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_&lpar;computing&rpar;) :-)
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2013">
@@ -3456,9 +3792,13 @@ fire](https://en.wikipedia.org/wiki/Halt_and_Catch_Fire_&lpar;computing&rpar;) :
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
+
 <div id="2013_cable2">
 ## 2013/cable2
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2013/cable2/cable2.c](%%REPO_URL%%/2013/cable2/cable2.c)
@@ -3478,10 +3818,14 @@ antialiasing interferes with color detection in "color" mode.
 - Only runs on little endian machines (since the BMP format is little endian,
 and endianness conversion would make the source too large for IOCCC rule 2).
 
+Jump to: [top](#)
 
 <div id="2013_dlowe">
 ## 2013/dlowe
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2013/dlowe/dlowe.c](%%REPO_URL%%/2013/dlowe/dlowe.c)
@@ -3502,10 +3846,13 @@ The author also stated:
 * Only works if your terminal is UTF-8 and your font supports the 8 glyphs
   used.
 
+Jump to: [top](#)
 
 <div id="2013_endoh1">
 ## 2013/endoh1
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2013/endoh1/endoh1.c](%%REPO_URL%%/2013/endoh1/endoh1.c)
@@ -3514,19 +3861,22 @@ The author also stated:
 > This program supports only "Combinator-calculus style notation" of Lazy K.
 "Unlambda style" and "Iota and Jot" style are not supported.
 >
-
+>
 > Also, it requires a space between identifiers.  In short, use `(S K)` instead of
 > `(SK)`, "\`sk", `**i*i*i*ii*i*i*ii`, or `11111100011100`.
 >
 > Huge memory may be required to compile the program (about 300 MB on my machine).
 >
->In addition, there are some limitations (and workarounds) mentioned in the
+> In addition, there are some limitations (and workarounds) mentioned in the
 [obfuscation section](2013/endoh1/index.html#obfuscation).
 
+Jump to: [top](#)
 
 <div id="2013_endoh3">
 ## 2013/endoh3
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2013/endoh3/endoh3.c](%%REPO_URL%%/2013/endoh3/endoh3.c)
@@ -3541,10 +3891,13 @@ From the author:
 >
 > A workaround is inserting a whitespace: `C2 E2`.
 
+Jump to: [top](#)
 
 <div id="2013_endoh4">
 ## 2013/endoh4
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2013/endoh4/endoh4.c](%%REPO_URL%%/2013/endoh4/endoh4.c)
@@ -3552,10 +3905,13 @@ From the author:
 
 Invalid input files will very likely crash the program.
 
+Jump to: [top](#)
 
 <div id="2013_hou">
 ## 2013/hou
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2013/hou/hou.c](%%REPO_URL%%/2013/hou/hou.c)
@@ -3564,10 +3920,13 @@ Invalid input files will very likely crash the program.
 This program will not terminate on its own; you must kill `hou` (but not Qiming
 Hou :-) ) yourself. This should not be fixed.
 
+Jump to: [top](#)
 
 <div id="2013_mills">
 ## 2013/mills
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2013/mills/mills.c](%%REPO_URL%%/2013/mills/mills.c)
@@ -3580,6 +3939,7 @@ document but the author does mention the well known (at least to those of us who
 have experience with socket programming :-) ) fix. However as the author pointed
 it out as a known limitation it is not a bug but a feature.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2014">
@@ -3587,10 +3947,13 @@ it out as a known limitation it is not a bug but a feature.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2014_maffiodo1">
 ## 2014/maffiodo1
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2014/maffiodo1/prog.c](%%REPO_URL%%/2014/maffiodo1/prog.c)
@@ -3612,12 +3975,14 @@ On the other hand, the author also stated:
 collide with blocks and get stuck inside them. This is a KNOWN BUG. When your
 player become bigger, stay away from blocks!
 
-..  but since it's documented it's considered a feature, not a bug to fix.
-
+Jump to: [top](#)
 
 <div id="2014_maffiodo2">
 ## 2014/maffiodo2
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2014/maffiodo2/prog.c](%%REPO_URL%%/2014/maffiodo2/prog.c)
@@ -3625,10 +3990,13 @@ player become bigger, stay away from blocks!
 
 This program will very likely crash if no arg is given.
 
+Jump to: [top](#)
 
 <div id="2014_vik">
 ## 2014/vik
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [2014/vik/prog.c](%%REPO_URL%%/2014/vik/prog.c)
@@ -3679,6 +4047,7 @@ they will properly get:
     IOCCC
 ```
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2015">
@@ -3686,10 +4055,13 @@ they will properly get:
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2015_duble">
 ## 2015/duble
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2015/duble/prog.c](%%REPO_URL%%/2015/duble/prog.c)
@@ -3698,10 +4070,14 @@ they will properly get:
 This program is known to, in some cases, segfault, and as the judges and the
 author noted this, it should not be fixed.
 
+Jump to: [top](#)
 
 <div id="2015_hou">
 ## 2015/hou
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2015/hou/prog.c](%%REPO_URL%%/2015/hou/prog.c)
@@ -3711,26 +4087,29 @@ The author stated:
 
 > Hard requirements:
 >
-> * The platform must implement the `double` type as IEEE754-compliant 64-bit
+> The platform must implement the `double` type as IEEE754-compliant 64-bit
 floating point numbers.  The 80-bit intermediate format used by x87 is
 considered as an violation of this. The code should print an error message on
 such platforms.
 >
-> * The program must start with the CPU / FPU in round-to-nearest mode.
+> The program must start with the CPU / FPU in round-to-nearest mode.
 >
 > Soft requirements:
 >
-> * The compiler must respect `volatile`. The code is formatted to warn about
+> The compiler must respect `volatile`. The code is formatted to warn about
 that, though.
 >
-> * The printed result is only correct on little-endian machines. The program
+> The printed result is only correct on little-endian machines. The program
 takes care to warn about this issue after printing an incorrect big-endian
 result. Error messages become garbled, though.
 
+Jump to: [top](#)
 
 <div id="2015_howe">
 ## 2015/howe
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 
@@ -3755,10 +4134,14 @@ The same problem exists in the
 [prog.alt-test.sh](%%REPO_URL%%/2015/howe/prog.alt-test.sh), particularly
 because it is the same thing as the other, just updated to use `prog.alt`.
 
+Jump to: [top](#)
 
 <div id="2015_mills2">
 ## 2015/mills2
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2015/mills2/prog.c](%%REPO_URL%%/2015/mills2/prog.c)
@@ -3770,9 +4153,13 @@ is not compressed data it's likely to crash.
 The program depends on little endian systems.
 
 
+Jump to: [top](#)
+
 <div id="2015_schweikhardt">
 ## 2015/schweikhardt
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2015/schweikhardt/prog.c](%%REPO_URL%%/2015/schweikhardt/prog.c)
@@ -3789,6 +4176,7 @@ of bits in a type is `sizeof(typ) << 3`, it will work correctly on 24-bit or
 `int` and so on. On such systems, it will only use `8 * sizeof(typ)` bits per
 place. It does not work when `CHAR_BIT <= 7`.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2016">
@@ -3796,8 +4184,10 @@ place. It does not work when `CHAR_BIT <= 7`.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+
 There was no IOCCC in 2016.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2017">
@@ -3807,6 +4197,7 @@ There was no IOCCC in 2016.
 
 There was no IOCCC in 2017.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2018">
@@ -3814,10 +4205,13 @@ There was no IOCCC in 2017.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2018_algmyr">
 ## 2018/algmyr
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2018/algmyr/prog.c](%%REPO_URL%%/2018/algmyr/prog.c)
@@ -3836,11 +4230,15 @@ behavior. Some erroneous arguments cause segfaults (negative number of channels,
 channel id outside valid range). One argument in particular causes an infinite
 loop printing whitespace.
 
+Jump to: [top](#)
 
 
 <div id="2018_hou">
 ## 2018/hou
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2018/hou/prog.c](%%REPO_URL%%/2018/hou/prog.c)
@@ -3861,10 +4259,13 @@ Some JSON files might cause the program to continue to run and seemingly
 infinitely increase the size of the output file. This can happen if you try
 fixing the syntax error in the generated `ioccc.json` file.
 
+Jump to: [top](#)
 
 <div id="2018_mills">
 ## 2018/mills
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 ### Source code: [2018/mills/prog.c](%%REPO_URL%%/2018/mills/prog.c)
@@ -3882,6 +4283,7 @@ where `[]` is the cursor. When this happens if you hit enter (this is necessary
 or else it'll happen again) and then exit again (ctrl-e) and run `prog` again
 it'll be okay.
 
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 
@@ -3900,10 +4302,13 @@ Another issue noticed is that if you are using the saved mode you must type
 `sync` prior to exiting the program or else the next time you run it the file
 will not exist (or in the case of compiled code it won't be executable).
 
+Jump to: [top](#)
 
 <div id="2018_vokes">
 ## 2018/vokes
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2018/vokes/prog.c](%%REPO_URL%%/2018/vokes/prog.c)
@@ -3955,6 +4360,7 @@ The author wrote the following:
   the values `48` through `57`, rather than using `isdigit(3)`. As noted above,
   this program has nothing to do with a hand.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2019">
@@ -3962,10 +4368,13 @@ The author wrote the following:
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2019_adamovsky">
 ## 2019/adamovsky
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/adamovsky/prog.c](%%REPO_URL%%/2019/adamovsky/prog.c)
@@ -3974,10 +4383,13 @@ The author wrote the following:
 Certain input can crash this program. The file
 [crash.unl](%%REPO_URL%%/2019/adamovsky/crash.unl) is an example file.
 
+Jump to: [top](#)
 
 <div id="2019_burton">
 ## 2019/burton
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/burton/prog.c](%%REPO_URL%%/2019/burton/prog.c)
@@ -3986,10 +4398,13 @@ Certain input can crash this program. The file
 The author pointed out that some implementations of `wc(1)` show different
 values but his implementation matches that of macOS and FreeBSD.
 
+Jump to: [top](#)
 
 <div id="2019_ciura">
 ## 2019/ciura
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/ciura/prog.c](%%REPO_URL%%/2019/ciura/prog.c)
@@ -4024,9 +4439,13 @@ noted in the de.sh/de.alt.sh scripts:
     # reason that so many words have them.
 ```
 
+Jump to: [top](#)
+
 <div id="2019_dogon">
 ## 2019/dogon
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: uses gets() - change to fgets() if possible
 ### Source code: [2019/dogon/prog.c](%%REPO_URL%%/2019/dogon/prog.c)
@@ -4038,10 +4457,13 @@ See the
 FAQ on "[gets and fgets](faq.html#gets)"
 for more information on the change to `fgets(3)`.
 
+Jump to: [top](#)
 
 <div id="2019_duble">
 ## 2019/duble
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/duble/prog.c](%%REPO_URL%%/2019/duble/prog.c)
@@ -4067,12 +4489,13 @@ Ferguson](authors.html#Cody_Boone_Ferguson) showed us this:
     [...]
 ```
 
-This is NOT a bug and you'll have to (at least at this time?) delete the files
+This is NOT a bug and you'll have to delete the files
 manually. You shouldn't have to worry about these being added to git: it seems
 to ignore sockets (it did at least in macOS).
 
-He provides the following tips on this situation. A simpler way to find sockets
-in the directory:
+Jump to: [top](#)
+
+Tips on this situation. A simpler way to find sockets in the directory:
 
 ``` <!---sh-->
     file .*|grep socket|cut -f1 -d:
@@ -4086,10 +4509,13 @@ To delete them you can do:
 
 though one might want to check that the program is not currently running. :-)
 
+Jump to: [top](#)
 
 <div id="2019_endoh">
 ## 2019/endoh
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/endoh/prog.c](%%REPO_URL%%/2019/endoh/prog.c)
@@ -4098,10 +4524,13 @@ though one might want to check that the program is not currently running. :-)
 As a backtrace quine this entry is **SUPPOSED to segfault** so this should not be
 touched either.
 
+Jump to: [top](#)
 
 <div id="2019_karns">
 ## 2019/karns
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/karns/prog.c](%%REPO_URL%%/2019/karns/prog.c)
@@ -4124,10 +4553,16 @@ encountered this myself).
 - The program could be obfuscated much further.
 - The program contains some unused code and data.
 
+**NOTE**: the segfault problem might have been fixed when the optimiser was disabled
+(which was necessary as part of a bug fix).
+
+Jump to: [top](#)
 
 <div id="2019_lynn">
 ## 2019/lynn
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/lynn/prog.c](%%REPO_URL%%/2019/lynn/prog.c)
@@ -4138,10 +4573,13 @@ expect. Rather than duplicate the information we refer you to the author's
 remarks in the sections [Syntax](2019/lynn/index.html#syntax) and
 [Caveats](2019/lynn/index.html#caveats).
 
+Jump to: [top](#)
 
 <div id="2019_mills">
 ## 2019/mills
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/mills/prog.c](%%REPO_URL%%/2019/mills/prog.c)
@@ -4163,9 +4601,13 @@ shells, you can view the hard limit with ulimit -Hs and set it with ulimit -s
 view the hard limit with limit -h stacksize and set it with limit stacksize
 65532 (replacing 65532 with the actual hard limit).
 
+Jump to: [top](#)
+
 <div id="2019_poikola">
 ## 2019/poikola
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/poikola/prog.c](%%REPO_URL%%/2019/poikola/prog.c)
@@ -4176,9 +4618,13 @@ erroneously.
 
 Also, the maximum file size is 1GB.
 
+Jump to: [top](#)
+
 <div id="2019_yang">
 ## 2019/yang
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2019/yang/prog.c](%%REPO_URL%%/2019/yang/prog.c)
@@ -4190,6 +4636,7 @@ The author also stated that 'if input contains CR-LF end of line sequences,
 those `CR`s are silently dropped.  In fact, most control codes are silently
 ignored except line feeds (preserved) and tabs (expanded to 8 spaces).'
 
+Jump to: [top](#)
 
 
 
@@ -4199,10 +4646,14 @@ ignored except line feeds (preserved) and tabs (expanded to 8 spaces).'
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
+Jump to: [top](#)
 
 <div id="2020_burton">
 ## 2020/burton
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2020/burton/prog.c](%%REPO_URL%%/2020/burton/prog.c)
@@ -4215,10 +4666,14 @@ but it shouldn't be made into a pull request).
 It will also show funny output with more than one arg. This should not be fixed
 either. But can you figure out why this happens?
 
+Jump to: [top](#)
 
 <div id="2020_carlini">
 ## 2020/carlini
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2020/carlini/prog.c](%%REPO_URL%%/2020/carlini/prog.c)
@@ -4236,10 +4691,14 @@ move.
 
 If you have audible bells enabled the program will beep at every turn.
 
+Jump to: [top](#)
 
 <div id="2020_ferguson1">
 ## 2020/ferguson1
 </div>
+
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2020/ferguson1/prog.c](%%REPO_URL%%/2020/ferguson1/prog.c)
@@ -4250,10 +4709,13 @@ things that are misinterpreted as bugs. See the
 [bugs.html](2020/ferguson1/bugs.html) and
 [troubleshooting.html](2020/ferguson1/troubleshooting.html) files for details.
 
+Jump to: [top](#)
 
 <div id="2020_giles">
 ## 2020/giles
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2020/giles/prog.c](%%REPO_URL%%/2020/giles/prog.c)
@@ -4263,10 +4725,13 @@ The author noted that the program only supports WAV files that have
 exactly 16 bits per sample, but it allows any sample rate and any number of
 audio channels.
 
+Jump to: [top](#)
 
 <div id="2020_otterness">
 ## 2020/otterness
 </div>
+
+Jump to: [top](#)
 
 ### STATUS: INABIAF - please **DO NOT** fix
 ### Source code: [2020/otterness/prog.c](%%REPO_URL%%/2020/otterness/prog.c)
@@ -4291,6 +4756,7 @@ See also the [Program error
 codes](2020/otterness/index.html#program-error-codes) written by the author
 which lists some other conditions which should be considered features, not bugs.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2021">
@@ -4300,6 +4766,7 @@ which lists some other conditions which should be considered features, not bugs.
 
 There was no IOCCC in 2021.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2022">
@@ -4308,6 +4775,8 @@ There was no IOCCC in 2021.
 <hr style="width:10%;text-align:left;margin-left:0">
 
 There was no IOCCC in 2022.
+
+Jump to: [top](#)
 
 
 <hr style="width:10%;text-align:left;margin-left:0">
@@ -4318,6 +4787,8 @@ There was no IOCCC in 2022.
 
 There was no IOCCC in 2023.
 
+Jump to: [top](#)
+
 
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="2024">
@@ -4325,9 +4796,7 @@ There was no IOCCC in 2023.
 </div>
 <hr style="width:10%;text-align:left;margin-left:0">
 
-We hope to run the IOCCCMOCK this year, 2024, and hopefully the next IOCCC, but
-for now we wish everyone a happy new year!
-
+We plan to run IOCCC28 this year but the time has not been announced just yet.
 
 # Final words
 
@@ -4339,6 +4808,7 @@ request](https://github.com/ioccc-src/winner/pulls) or otherwise, we
 thank you as well for the help! We will happily add you to the
 [thanks](thanks-for-help.html) file as well.
 
+Jump to: [top](#)
 
 <hr style="width:10%;text-align:left;margin-left:0">
 

--- a/contact.html
+++ b/contact.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -455,6 +468,7 @@ FAQ on “<a href="faq.html#feedback">tools feedback</a>”</li>
 <p>Those FAQ entries will help guide you on how to make public comments
 and suggestion in the relevant places.</p>
 <p>See the above FAQ entries for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="try_mastodon">
 <h1 id="try-mastodon">Try Mastodon</h1>
 </div>
@@ -464,6 +478,7 @@ major events such as the opening of a new IOCCC, or who won.</p>
 <p>See the
 FAQ on “<a href="faq.html#try_mastodon">Mastodon</a>”
 for more information on Mastodon.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h1 id="if-you-really-need-to-send-email-the-ioccc-judges">If you really need to send email the IOCCC judges</h1>
 <p>Did you look at the above section?</p>
 <p>If you must contact the IOCCC judges by email, then please send email to:

--- a/contact.md
+++ b/contact.md
@@ -48,6 +48,8 @@ and suggestion in the relevant places.
 See the above FAQ entries for more details.
 
 
+Jump to: [top](#)
+
 <div id="try_mastodon">
 # Try Mastodon
 </div>
@@ -61,6 +63,7 @@ See the
 FAQ on "[Mastodon](faq.html#try_mastodon)"
 for more information on Mastodon.
 
+Jump to: [top](#)
 
 # If you really need to send email the IOCCC judges
 

--- a/faq.html
+++ b/faq.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -412,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.1.2 2024-10-21</strong>.</p>
+<p>This is FAQ version <strong>28.1.3 2024-10-25</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#submit">How can I enter the IOCCC?</a></li>
@@ -431,7 +444,7 @@
 <ul>
 <li><strong>Q 1.0</strong>: <a class="normal" href="#answers_file">How can I avoid reentering the information to mkiocccentry?</a></li>
 <li><strong>Q 1.1</strong>: <a class="normal" href="#prog_c">May I use a different source or compiled filename than prog.c or prog?</a></li>
-<li><strong>Q 1.2</strong>: <a class="normal" href="#markdown">What are the IOCCC best practices for using markdown?</a></li>
+<li><strong>Q 1.2</strong>: <a class="normal" href="#markdown">What is markdown and how does the IOCCC use it?</a></li>
 <li><strong>Q 1.3</strong>: <a class="normal" href="#mkiocccentry_bugs">How do I report bugs in an <code>mkiocccentry</code> tool?</a></li>
 </ul>
 <h2 id="ioccc-judging-process">2. <a href="#judging">IOCCC Judging process</a></h2>
@@ -532,7 +545,7 @@
 <h2 id="miscellaneous-ioccc">10. <a href="#misc">Miscellaneous IOCCC</a></h2>
 <ul>
 <li><strong>Q 10.0</strong>: <a class="normal" href="#mirrors">May I mirror the IOCCC website?</a></li>
-<li><strong>Q 10.1</strong>: <a class="normal" href="#ioccc_copyright">Mat I use IOCCC content in an article, book, newsletter, or instructional material?</a></li>
+<li><strong>Q 10.1</strong>: <a class="normal" href="#ioccc_copyright">May I use IOCCC content in an article, book, newsletter, or instructional material?</a></li>
 <li><strong>Q 10.2</strong>: <a class="normal" href="#first_person">Why do you sometimes use the first person plural?</a></li>
 <li><strong>Q 10.3</strong>: <a class="normal" href="#dot_files"> What is the purpose of the <code>.top</code>, <code>.allyear</code>, <code>.year</code> and <code>.path</code> files?</a></li>
 <li><strong>Q 10.4</strong>: <a class="normal" href="#terms"> What is the current meaning of the IOCCC terms Author, Entry, and Submission?</a></li>
@@ -832,7 +845,7 @@ program(s), clean up any files made by the program etc.</li>
 </div>
 </div>
 </div>
-<p>First, <strong>PLEASE</strong> read the <a href="markdown.html">IOCCC Markdown Guidelines</a>.</p>
+<p>First, <strong>PLEASE</strong> read the <a href="markdown.html">IOCCC markdown guidelines</a>.</p>
 <p>Next, while you may put in as much or as little as you wish into your entry’s
 <code>remarks.md</code> file, we do have few important suggestions:</p>
 <p>We recommend that you explain how to use your entry. Explain the
@@ -933,7 +946,7 @@ For example:</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="markdown">
 <div id="md">
-<h3 id="q-1.2-what-are-the-ioccc-best-practices-for-using-markdown">Q 1.2: What are the IOCCC best practices for using markdown?</h3>
+<h3 id="q-1.2-what-is-markdown-and-how-does-the-ioccc-use-it">Q 1.2: What is markdown and how does the IOCCC use it?</h3>
 </div>
 </div>
 <p>The IOCCC makes extensive use of <a href="https://daringfireball.net/projects/markdown/">markdown</a>.
@@ -943,8 +956,9 @@ submit remarks about entry in markdown format. Every
 as the basis for forming the <code>index.html</code> web page for that entry.
 All generated HTML pages on the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a>
 start with some markdown content.</p>
-<p><strong>IMPORTANT</strong>: Please read the <a href="markdown.html">IOCCC markdown best practices</a> guide
-as it lists things you <strong>should not use</strong> in markdown files.</p>
+<p><strong>IMPORTANT</strong>: Please read the <a href="markdown.html">IOCCC markdown guidelines</a>
+as it lists things you <strong>should NOT use</strong> in markdown files and things you
+<strong>should do</strong> as well.</p>
 <p>See the <a href="https://www.markdownguide.org/basic-syntax">markdown syntax</a> guide.
 See also <a href="https://spec.commonmark.org/current/">CommonMark Spec</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
@@ -4893,7 +4907,7 @@ date with the latest changes when possible. Thank you.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="permission">
 <div id="ioccc_copyright">
-<h3 id="q-10.1-mat-i-use-ioccc-content-in-an-article-book-newsletter-or-instructional-material">Q 10.1: Mat I use IOCCC content in an article, book, newsletter, or instructional material?</h3>
+<h3 id="q-10.1-may-i-use-ioccc-content-in-an-article-book-newsletter-or-instructional-material">Q 10.1: May I use IOCCC content in an article, book, newsletter, or instructional material?</h3>
 </div>
 </div>
 <p>While IOCCC judges look favorably on most requests to use IOCCC material,
@@ -5527,47 +5541,7 @@ announced in the early years of the IOCCC.</p>
 <div id="explain_IOCCC">
 <h3 id="q-11.6-i-do-not-understand-the-ioccc-can-you-explain-it-to-me">Q 11.6: I do not understand the IOCCC, can you explain it to me?</h3>
 </div>
-<p>The IOCCC stands for the International Obfuscated C Code Contest.
-The IOCCC is a C programming contest.</p>
-<p>The goals of the IOCCC are:</p>
-<ul>
-<li>To write the most Obscure/Obfuscated C program within the rules.</li>
-<li>To show the importance of programming style, in an ironic way.</li>
-<li>To stress C compilers with unusual code.</li>
-<li>To illustrate some of the subtleties of the C language.</li>
-<li>To provide a safe forum for poor C code. :-)</li>
-<li>To have fun with C!</li>
-</ul>
-<p>See the
-FAQ on “<a href="#ioccc_start">start of the IOCCC</a>”
-and the
-FAQ on “<a href="#website_history">history of the IOCCC</a>”
-for more information the background of the IOCCC.</p>
-<p>See the
-FAQ on “<a href="#submit">entering the IOCCC</a>”
-for information on how to enter and submit to the IOCCC.</p>
-<p>If you are still confused, consider the nature of
-the <a href="next/rules.html">IOCCC rules</a> and of the <a href="next/guidelines.html">IOCCC
-guidelines</a>. You will see a dose of the technical,
-mixed with “nerd humor” (or humour if you prefer 🤓).</p>
-<p>If after all that you are still confused, sorry (tm Canada 😉).
-Consider this: While the IOCCC often attempts to be presentable,
-it is under no obligation to be wholly understandable. One might
-say that to truly understand the IOCCC is problematic. And if
-someone did manage to fully understand the IOCCC, then perhaps
-this <strong>modified</strong> quote from the <a href="https://en.wikipedia.org/wiki/The_Hitchhiker&#39;s_Guide_to_the_Galaxy">The Hitchhiker’s Guide to the
-Galaxy</a>
-may apply:</p>
-<blockquote>
-<p>“There is a theory which states that if ever anyone discovers
-exactly what the IOCCC is for and why it is here, it will
-instantly disappear and be replaced by something even more bizarre
-and inexplicable.</p>
-<p>There is another theory which states that this has
-<a href="#great_fork_merge">already happened</a>.” 😜</p>
-</blockquote>
-<p>Share and enjoy! ☺️</p>
-<p>Jump to: <a href="#">top</a></p>
+<p>Please see the <a href="about.html">About the IOCCC page</a> for more details.</p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **28.1.2 2024-10-21**.
+This is FAQ version **28.1.3 2024-10-25**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
@@ -18,7 +18,7 @@ This is FAQ version **28.1.2 2024-10-21**.
 ## 1. [Entering the IOCCC: more help and details](#submitting_help)
 - **Q 1.0**: <a class="normal" href="#answers_file">How can I avoid reentering the information to mkiocccentry?</a>
 - **Q 1.1**: <a class="normal" href="#prog_c">May I use a different source or compiled filename than prog.c or prog?</a>
-- **Q 1.2**: <a class="normal" href="#markdown">What are the IOCCC best practices for using markdown?</a>
+- **Q 1.2**: <a class="normal" href="#markdown">What is markdown and how does the IOCCC use it?</a>
 - **Q 1.3**: <a class="normal" href="#mkiocccentry_bugs">How do I report bugs in an `mkiocccentry` tool?</a>
 
 
@@ -115,7 +115,7 @@ This is FAQ version **28.1.2 2024-10-21**.
 
 ## 10. [Miscellaneous IOCCC](#misc)
 - **Q 10.0**: <a class="normal" href="#mirrors">May I mirror the IOCCC website?</a>
-- **Q 10.1**: <a class="normal" href="#ioccc_copyright">Mat I use IOCCC content in an article, book, newsletter, or instructional material?</a>
+- **Q 10.1**: <a class="normal" href="#ioccc_copyright">May I use IOCCC content in an article, book, newsletter, or instructional material?</a>
 - **Q 10.2**: <a class="normal" href="#first_person">Why do you sometimes use the first person plural?</a>
 - **Q 10.3**: <a class="normal" href="#dot_files"> What is the purpose of the `.top`, `.allyear`, `.year` and `.path` files?</a>
 - **Q 10.4**: <a class="normal" href="#terms"> What is the current meaning of the IOCCC terms Author, Entry, and Submission?</a>
@@ -660,7 +660,7 @@ Jump to: [top](#)
 
 <div id="markdown">
 <div id="md">
-### Q 1.2: What are the IOCCC best practices for using markdown?
+### Q 1.2: What is markdown and how does the IOCCC use it?
 </div>
 </div>
 
@@ -672,8 +672,9 @@ as the basis for forming the `index.html` web page for that entry.
 All generated HTML pages on the [Official IOCCC website](https://www.ioccc.org/index.html)
 start with some markdown content.
 
-**IMPORTANT**: Please read the [IOCCC markdown best practices](markdown.html) guide
-as it lists things you **should not use** in markdown files.
+**IMPORTANT**: Please read the [IOCCC markdown guidelines](markdown.html)
+as it lists things you **should NOT use** in markdown files and things you
+**should do** as well.
 
 See the [markdown syntax](https://www.markdownguide.org/basic-syntax) guide.
 See also [CommonMark Spec](https://spec.commonmark.org/current/).
@@ -6095,7 +6096,7 @@ Jump to: [top](#)
 
 <div id="permission">
 <div id="ioccc_copyright">
-### Q 10.1: Mat I use IOCCC content in an article, book, newsletter, or instructional material?
+### Q 10.1: May I use IOCCC content in an article, book, newsletter, or instructional material?
 </div>
 </div>
 
@@ -6932,53 +6933,7 @@ Jump to: [top](#)
 ### Q 11.6: I do not understand the IOCCC, can you explain it to me?
 </div>
 
-The IOCCC stands for the International Obfuscated C Code Contest.
-The IOCCC is a C programming contest.
-
-The goals of the IOCCC are:
-
-* To write the most Obscure/Obfuscated C program within the rules.
-* To show the importance of programming style, in an ironic way.
-* To stress C compilers with unusual code.
-* To illustrate some of the subtleties of the C language.
-* To provide a safe forum for poor C code. :-)
-* To have fun with C!
-
-See the
-FAQ on "[start of the IOCCC](#ioccc_start)"
-and the
-FAQ on "[history of the IOCCC](#website_history)"
-for more information the background of the IOCCC.
-
-See the
-FAQ on "[entering the IOCCC](#submit)"
-for information on how to enter and submit to the IOCCC.
-
-If you are still confused, consider the nature of
-the [IOCCC rules](next/rules.html) and of the [IOCCC
-guidelines](next/guidelines.html).  You will see a dose of the technical,
-mixed with "nerd humor" (or humour if you prefer 🤓).
-
-If after all that you are still confused, sorry (tm Canada 😉).
-Consider this: While the IOCCC often attempts to be presentable,
-it is under no obligation to be wholly understandable.  One might
-say that to truly understand the IOCCC is problematic. And if
-someone did manage to fully understand the IOCCC, then perhaps
-this **modified** quote from the [The Hitchhiker's Guide to the
-Galaxy](https://en.wikipedia.org/wiki/The_Hitchhiker's_Guide_to_the_Galaxy)
-may apply:
-
-> "There is a theory which states that if ever anyone discovers
-exactly what the IOCCC is for and why it is here, it will
-instantly disappear and be replaced by something even more bizarre
-and inexplicable.
->
-> There is another theory which states that this has
-[already happened](#great_fork_merge)." 😜
-
-Share and enjoy! ☺️
-
-Jump to: [top](#)
+Please see the [About the IOCCC page](about.html) for more details.
 
 
 <!--

--- a/inc/index.html
+++ b/inc/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/inc/topbar.default.html
+++ b/inc/topbar.default.html
@@ -18,25 +18,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="%%DOCROOT_SLASH%%faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="%%DOCROOT_SLASH%%faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="%%DOCROOT_SLASH%%thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -50,7 +68,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -62,15 +80,22 @@
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="%%DOCROOT_SLASH%%SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -82,33 +107,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="%%DOCROOT_SLASH%%faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="%%DOCROOT_SLASH%%faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="%%DOCROOT_SLASH%%faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -120,43 +146,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="%%DOCROOT_SLASH%%about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="%%DOCROOT_SLASH%%contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -198,11 +206,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%location.html">
@@ -213,6 +221,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -223,22 +242,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -253,19 +275,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -278,31 +300,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/judges.html
+++ b/judges.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -417,7 +430,7 @@
 <li><a href="http://www.isthe.com/chongo/">Landon Curt Noll</a></li>
 </ul>
 <h3 id="if-you-want-to-contact-the-ioccc-judges-please-visit">If you want to contact the IOCCC judges, please visit:</h3>
-<p><a href="contact.html">Contacting the IOCCC</a></p>
+<p><a href="contact.html">Contacting the Judges</a></p>
 <!--
 
     Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.

--- a/judges.md
+++ b/judges.md
@@ -5,7 +5,7 @@
 
 ### If you want to contact the IOCCC judges, please visit:
 
-[Contacting the IOCCC](contact.html)
+[Contacting the Judges](contact.html)
 
 
 <!--

--- a/license.html
+++ b/license.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/location.html
+++ b/location.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/markdown.html
+++ b/markdown.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -411,8 +424,20 @@
 <!-- START: this line starts content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 
 <!-- BEFORE: 1st line of markdown file: markdown.md -->
-<div id="guidelines">
-<h1 id="ioccc-markdown-guidelines">IOCCC markdown guidelines</h1>
+<div id="markdown_guidelines">
+<h1 id="ioccc-28th-markdown-guidelines">IOCCC 28th Markdown Guidelines</h1>
+</div>
+<div id="markdown_version">
+<h2 id="ioccc-markdown-guidelines-version">IOCCC Markdown guidelines version</h2>
+</div>
+<p class="leftbar">
+These <a href="markdown.html">IOCCC markdown guidelines</a> are version <strong>28.0 2024-10-25</strong>.
+</p>
+<p><strong>IMPORTANT</strong>: Be sure to read the <a href="next/rules.html">IOCCC rules</a> and <a href="next/guidelines.html">IOCCC
+guidelines</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
+<div id="markdown">
+<h2 id="ioccc-markdown-guidelines">IOCCC Markdown guidelines</h2>
 </div>
 <p>The IOCCC makes extensive use of <a href="https://daringfireball.net/projects/markdown/">markdown</a>.
 For example, when submitting to the IOCCC
@@ -431,6 +456,7 @@ Some of these relate to use of markdown directly and others relate to injecting 
 into the markdown file.</p>
 <p>In particular there are things we ask people to please <strong>NOT</strong> use in
 markdown files for the IOCCC:</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="name">
 <div id="anchor-name">
 <h2 id="please-do-not-use-the-name-attributes-in-html-a...a-hyperlink-elements">Please do NOT use the <code>name</code> attributes in HTML <code>&lt;a&gt;...&lt;/a&gt;</code> hyperlink elements</h2>
@@ -454,6 +480,7 @@ for the given page URL.</p>
     # This will work
     &lt;/div&gt;</code></pre>
 <p>While some browsers will still recognize the HTML construct <code>&lt;a name="string"&gt;...&lt;/a&gt;</code>, it is possible <strong>they MIGHT NOT</strong> in the future.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="links">
 <h2 id="if-you-can-it-is-preferable-to-use-markdown-links-rather-than-a...a">If you can, it is PREFERABLE to use markdown links rather than <code>&lt;a&gt;...&lt;/a&gt;</code></h2>
 </div>
@@ -463,6 +490,7 @@ anchors.</p>
 <pre><code>    Use of &lt;a href=&quot;#links&gt;HTML anchors&lt;/a&gt;
             is one option, however ...</code></pre>
 <pre><code>    [markdown links](#links) are easier and preferred</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="strike">
 <div id="del">
 <h2 id="please-do-not-use-the-strike-or-the-s-html-element">Please do NOT use the <code>&lt;strike&gt;</code> or the <code>&lt;s&gt;</code> HTML element</h2>
@@ -474,6 +502,7 @@ anchors.</p>
     &lt;s&gt;...&lt;/s&gt;                                                &lt;=== no thank you</code></pre>
 <p>Use instead:</p>
 <pre><code>    &lt;del&gt;...&lt;/del&gt;</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="underline">
 <div id="ins">
 <h2 id="please-do-not-use-the-u-html-element">Please do NOT use the <code>&lt;u&gt;</code> HTML element</h2>
@@ -483,6 +512,7 @@ anchors.</p>
 <pre><code>    &lt;u&gt;...&lt;/u&gt;                                                &lt;=== no thank you</code></pre>
 <p>Use instead:</p>
 <pre><code>    &lt;ins&gt;...&lt;/ins&gt;</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="tt">
 <div id="span">
 <h2 id="please-do-not-use-the-tt-html-element">Please do NOT use the <code>&lt;tt&gt;</code> HTML element</h2>
@@ -497,6 +527,7 @@ anchors.</p>
                                           however ... &lt;/span&gt;</code></pre>
 <p>We recommend using the inline markdown code block method instead:</p>
 <pre><code>    Using the `inline markdown code block` is easier and is **preferred**.</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="unindented">
 <div id="indented">
 <h2 id="please-do-not-use-unindented-code-blocks">Please do NOT use unindented code blocks</h2>
@@ -523,6 +554,7 @@ echo &quot;This code block is NOT indented&quot;                        &lt;=== 
     The same thing applies to any markdown block surrounded by ``` lines.
 ```</code></pre>
 <p>Please do <strong>NOT</strong> indent using ASCII tab characters in markdown files.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="tabs">
 <div id="spaces">
 <h2 id="please-do-not-use-ascii-tabs-in-markdown-files">Please do NOT use ASCII tabs in markdown files</h2>
@@ -553,6 +585,7 @@ not C code or any other non-markdown content:</p>
 <p><strong>NOTE</strong>: Again, you are <strong>perfectly welcome</strong> to use ASCII tab characters in
 your C code and other non-markdown files. We simply ask that you do <strong>NOT</strong> use any
 ASCII tab characters in markdown files.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="vim-tabs">
 <h3 id="tip-for-vim-users">Tip for <code>vim</code> users</h3>
 </div>
@@ -571,6 +604,7 @@ spaces.</p>
 <p>To <strong>VERIFY</strong> that there are no tabs in a file you may do, in command mode:</p>
 <pre><code>    /\t</code></pre>
 <p>If you’re in insert mode hit <code>ESC</code> first.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="languages">
 <div id="code">
 <h2 id="please-use-html-comments-to-specify-a-language-for-a-code-block">Please use HTML comments to specify a language for a code block</h2>
@@ -592,6 +626,7 @@ markdown code block starting fence by a space:</p>
 and <strong>THEN</strong> an <strong>opening</strong> <strong><code>&lt;!---</code></strong> (a “<code>&lt;</code>”, a “<code>!</code>” and then three “<code>-</code>”s), and
 <strong>THEN</strong> the <strong>language</strong> and <strong>FINALLY</strong> a <strong>closing</strong> “<code>--&gt;</code>” (two “<code>-</code>”s
 followed by a “<code>&gt;</code>”).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="slash">
 <div id="void">
 <h2 id="please-do-not-add-trailing-slash-to-void-html-elements">Please do NOT add trailing slash to void HTML elements</h2>
@@ -622,6 +657,7 @@ unquoted attribute values.</p>
      alt=&quot;image of a tattoo of the 1984 anonymous C code&quot;
      width=600 height=401&gt;</code></pre>
 <p>etc.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="backslash">
 <div id="br">
 <h2 id="please-do-not-use-a-trailing-backslash-outside-of-a-code-block">Please do NOT use a TRAILING backslash (<code>\</code>) outside of a code block</h2>
@@ -651,6 +687,7 @@ a trailing <code>&lt;br&gt;</code>.</p>
 <pre><code>    `This is OK\`</code></pre>
 <p>Doing it this way will prevent <code>pandoc(1)</code> from generating deprecated HTML
 elements such as <code>&lt;br /&gt;</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="images">
 <div id="img">
 <h2 id="please-do-not-use-markdown-style-images">Please do NOT use markdown style images</h2>
@@ -675,6 +712,7 @@ HTML from the markdown image construct, the resulting HTML does <strong>NOT</str
 have <code>width</code> and <code>height</code> information so browsers have to slow down
 on rendering text around the image until it can internally determine
 the image size.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="hr">
 <div id="horizontal">
 <div id="lines">
@@ -692,6 +730,7 @@ effect in standard HTML 5 and interacts badly with unquoted attribute values.</p
 <pre><code>    &lt;hr&gt;</code></pre>
 <p>If a short line is needed, use:</p>
 <pre><code>    &lt;hr style=&quot;width:10%;text-align:left;margin-left:0&quot;&gt;</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="parentheses">
 <h2 id="please-do-not-put-a-literal-or-in-markdown-link-titles">Please do NOT put a LITERAL “<code>(</code>” or “<code>)</code>” in markdown link titles</h2>
 </div>
@@ -704,6 +743,7 @@ effect in standard HTML 5 and interacts badly with unquoted attribute values.</p
 <pre><code>    [ls(1)](https://example.com/ls-man-page.1)                &lt;=== no thank you</code></pre>
 <p>use:</p>
 <pre><code>    [ls&amp;lpar;1&amp;rpar;](https://example.com/ls-man-page.1)</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="closing-parentheses">
 <h2 id="please-do-not-end-markdown-links-with">Please do NOT end markdown links with “<code>))</code>”</h2>
 </div>
@@ -718,6 +758,7 @@ to incorrect URLs or file paths.</p>
 <pre><code>    This thing, ([some text](some/path)), is NOT ideal.       &lt;=== no thank you</code></pre>
 <p>use:</p>
 <pre><code>    This thing, [some text](some/path), is better.</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="code-text">
 <div id="code-and-text">
 <div id="text">
@@ -749,6 +790,7 @@ C compilers cannot be given a -Wno-main-arg-errors flag.      &lt;=== no thank y
 
 C compilers cannot be given a -Wno-main-arg-errors flag.</code></pre>
 <p><strong>BTW</strong>: Please note the blank line after the code block.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="italics">
 <h2 id="please-use-_-for-italics-in-markdown">Please use <code>_</code> for italics in markdown</h2>
 </div>

--- a/markdown.md
+++ b/markdown.md
@@ -1,5 +1,23 @@
-<div id="guidelines">
-# IOCCC markdown guidelines
+<div id="markdown_guidelines">
+# IOCCC 28th Markdown Guidelines
+</div>
+
+<div id="markdown_version">
+## IOCCC Markdown guidelines version
+</div>
+
+<p class="leftbar">
+These [IOCCC markdown guidelines](markdown.html) are version **28.0 2024-10-25**.
+</p>
+
+**IMPORTANT**: Be sure to read the [IOCCC rules](next/rules.html) and [IOCCC
+guidelines](next/guidelines.html).
+
+
+Jump to: [top](#)
+
+<div id="markdown">
+## IOCCC Markdown guidelines
 </div>
 
 The IOCCC makes extensive use of [markdown](https://daringfireball.net/projects/markdown/).
@@ -23,6 +41,7 @@ into the markdown file.
 In particular there are things we ask people to please **NOT** use in
 markdown files for the IOCCC:
 
+Jump to: [top](#)
 
 <div id="name">
 <div id="anchor-name">
@@ -73,6 +92,7 @@ id="string">...</div>` element, as in:
 While some browsers will still recognize the HTML construct `<a
 name="string">...</a>`, it is possible **they MIGHT NOT** in the future.
 
+Jump to: [top](#)
 
 <div id="links">
 ## If you can, it is PREFERABLE to use markdown links rather than `<a>...</a>`
@@ -94,6 +114,7 @@ Instead of:
     [markdown links](#links) are easier and preferred
 ```
 
+Jump to: [top](#)
 
 <div id="strike">
 <div id="del">
@@ -115,6 +136,7 @@ Use instead:
     <del>...</del>
 ```
 
+Jump to: [top](#)
 
 <div id="underline">
 <div id="ins">
@@ -134,6 +156,7 @@ Use instead:
     <ins>...</ins>
 ```
 
+Jump to: [top](#)
 
 <div id="tt">
 <div id="span">
@@ -162,6 +185,7 @@ We recommend using the inline markdown code block method instead:
     Using the `inline markdown code block` is easier and is **preferred**.
 ```
 
+Jump to: [top](#)
 
 <div id="unindented">
 <div id="indented">
@@ -204,6 +228,7 @@ Moreover:
 
 Please do **NOT** indent using ASCII tab characters in markdown files.
 
+Jump to: [top](#)
 
 <div id="tabs">
 <div id="spaces">
@@ -248,6 +273,8 @@ not C code or any other non-markdown content:
 your C code and other non-markdown files.  We simply ask that you do **NOT** use any
 ASCII tab characters in markdown files.
 
+Jump to: [top](#)
+
 <div id="vim-tabs">
 ### Tip for `vim` users
 </div>
@@ -282,6 +309,7 @@ To **VERIFY** that there are no tabs in a file you may do, in command mode:
 
 If you're in insert mode hit `ESC` first.
 
+Jump to: [top](#)
 
 <div id="languages">
 <div id="code">
@@ -316,6 +344,7 @@ and **THEN** an **opening** **`<!---`** (a "`<`", a "`!`" and then three "`-`"s)
 followed by a "`>`").
 
 
+Jump to: [top](#)
 
 <div id="slash">
 <div id="void">
@@ -380,6 +409,7 @@ Instead use just:
 
 etc.
 
+Jump to: [top](#)
 
 <div id="backslash">
 <div id="br">
@@ -429,6 +459,7 @@ as is:
 Doing it this way will prevent `pandoc(1)` from generating deprecated HTML
 elements such as `<br />`.
 
+Jump to: [top](#)
 
 <div id="images">
 <div id="img">
@@ -473,6 +504,7 @@ have `width` and `height` information so browsers have to slow down
 on rendering text around the image until it can internally determine
 the image size.
 
+Jump to: [top](#)
 
 <div id="hr">
 <div id="horizontal">
@@ -504,6 +536,7 @@ If a short line is needed, use:
 ```
 
 
+Jump to: [top](#)
 
 <div id="parentheses">
 ## Please do NOT put a LITERAL "`(`" or "`)`" in markdown link titles
@@ -535,6 +568,7 @@ use:
     [ls&lpar;1&rpar;](https://example.com/ls-man-page.1)
 ```
 
+Jump to: [top](#)
 
 <div id="closing-parentheses">
 ## Please do NOT end markdown links with "`))`"
@@ -570,6 +604,8 @@ use:
 ``` <!---markdown-->
     This thing, [some text](some/path), is better.
 ```
+
+Jump to: [top](#)
 
 <div id="code-text">
 <div id="code-and-text">
@@ -613,6 +649,7 @@ C compilers cannot be given a -Wno-main-arg-errors flag.
 
 **BTW**: Please note the blank line after the code block.
 
+Jump to: [top](#)
 
 <div id="italics">
 ## Please use `_` for italics in markdown

--- a/news.html
+++ b/news.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -445,13 +458,15 @@ Copyright © 2024 Leonid A. Broukhis and Landon Curt Noll.
 granted provided this this copyright and notice are included in its entirety
 and remains unaltered. All other uses must receive prior permission in
 writing by <a href="../contact.html">contacting the judges</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="guidelines_version">
 <h2 id="ioccc-guidelines-version">IOCCC Guidelines version</h2>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.18 2024-10-21</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.19 2024-10-25</strong>.
 </p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="change_marks">
 <h3 id="change-marks">Change marks</h3>
 </div>
@@ -462,6 +477,7 @@ previous IOCCC</strong>.
 <p>Most lines (we sometimes make mistakes) that were modified since the previous
 IOCCC start with a solid 4 pixel black left border (or, in the case of a code
 block or blockquote, just a vertical bar).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="about_guidelines">
 <h1 id="about-this-file">ABOUT THIS FILE:</h1>
 </div>
@@ -477,6 +493,7 @@ guidelines</a>.</p>
 <p><strong>You should read the current <a href="rules.html">IOCCC rules</a>, prior to submitting
 entries</strong>. The <a href="rules.html">rules</a> are typically published along with the <a href="guidelines.html">IOCCC
 guidelines</a>..</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="new">
 <h1 id="whats-new-this-ioccc">WHAT’S NEW THIS IOCCC</h1>
 </div>
@@ -542,6 +559,7 @@ it</strong>.
 The IOCCC submission URL, <a href="../status.html#open">when the IOCCC is open</a>, is
 <a href="https://submit.ioccc.org/">submit.ioccc.org</a>.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="hints">
 <div id="suggestions">
 <h1 id="hints-and-suggestions">HINTS AND SUGGESTIONS:</h1>
@@ -676,6 +694,7 @@ The <a href="rules.html#rule2a">Rule 2a</a> size was changed from
 value similar to the <a href="../faq.html#size_rule2001-2012">2001-2012</a> and
 <a href="../faq.html#size_rule2013-2020">2013-2020</a> IOCCC eras.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="mkiocccentry"><code>mkiocccentry</code></h2>
 <p class="leftbar">
 <a href="rules.html#rule17">Rule 17</a> (the <code>mkiocccentry(1)</code> rule) states that
@@ -730,6 +749,7 @@ NOT recommend these options.
 In many places it will prompt you to verify what you input, allowing you to
 correct details as you go along.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="mkiocccentry-synopsis">
 <h2 id="mkiocccentry1-synopsis"><code>mkiocccentry(1)</code> synopsis</h2>
 </div>
@@ -753,12 +773,14 @@ for how to use this tool in more detail.
 <p class="leftbar">
 Below are the tools that <code>mkiocccentry(1)</code> will run.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="iocccsize"><code>iocccsize</code></h2>
 <p class="leftbar">
 <code>mkiocccentry(1)</code> will use code from <code>iocccsize(1)</code> which
 detects a number of issues that you may ignore, if you wish, as described above.
 As we already discussed how to invoke this we will not include it here again.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="chkentry"><code>chkentry</code></h2>
 <p class="leftbar">
 <code>mkiocccentry(1)</code> will write two JSON files: <code>.auth.json</code> and
@@ -790,6 +812,7 @@ and the
 FAQ on “<a href="../faq.html#info_json">.info.json</a>”
 for much more information on these files.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="txzchk"><code>txzchk</code></h2>
 <p class="leftbar">
 <code>txzchk(1)</code> performs a wide number of sanity checks on the xz
@@ -829,6 +852,7 @@ manually package your submission tarball, you could still be violating <a href="
 See also the
 FAQ on “<a href="../faq.html#txzchk">txzchk</a>”.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <h2 id="fnamchk"><code>fnamchk</code></h2>
 <p class="leftbar">
 A tool that <a href="#txzchk">txzchk</a> runs is <code>fnamchk</code>. This is an important part of
@@ -998,6 +1022,7 @@ use the <code>COTHER</code> Makefile variable. For example:
 <strong>NOTE</strong>: <strong>We only recommend using “<em>magic</em>” flags if <em>BOTH</em> <code>gcc</code>
 <em>and</em> <code>clang</code></strong> support it.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="likes">
 <div id="dislikes">
 <h1 id="our-likes-and-dislikes">OUR LIKES AND DISLIKES:</h1>
@@ -1541,10 +1566,11 @@ aware that some people may use tab stop that is different than the common 8
 character tab stop.
 </p>
 <p class="leftbar">
-<strong>PLEASE</strong> observe our <a href="../markdown.html">IOCCC Markdown Guidelines</a>
+<strong>PLEASE</strong> observe our <a href="../markdown.html">IOCCC markdown guidelines</a>
 when forming your submission’s <code>remarks.md</code> file. And if your submission
-contains additional markdown files, please follow those same guidelines. See
-also <a href="rules.html#rule19">Rule 19</a>.
+contains additional markdown files, please follow those same guidelines for
+those files. See also <a href="rules.html#rule19">Rule 19</a> and our
+FAQ on “<a href="../faq.html#markdown">markdown</a>”.
 </p>
 <p class="leftbar">
 We <strong>LIKE</strong> reading <code>remarks.md</code> files, especially if they contain
@@ -1555,6 +1581,7 @@ is a <strong>hint</strong>. :-)
 We <strong>RECOMMEND</strong> you put a reasonable amount effort into the content of the
 <code>remarks.md</code> file: it is a required for a reason. :-)
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rules_abuse">
 <div id="abusing_rules">
 <h1 id="abusing-the-rules">ABUSING THE RULES:</h1>
@@ -1613,6 +1640,7 @@ sometimes conflicting specifications and requirements from marketing, sales,
 product management an even from customers themselves on a all too regular basis.
 This is one of the reasons why the <a href="rules.html">IOCCC rules</a> and
 <a href="guidelines.html">IOCCC guidelines</a> are written in obfuscated form.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="judging">
 <h1 id="judging-process">JUDGING PROCESS:</h1>
 </div>
@@ -1667,6 +1695,7 @@ account</a>.
 <strong>Make sure you reload the feed</strong> every so often <strong>because unless you
 are mentioned you will NOT get a push notification!</strong>
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rounds">
 <h2 id="judging-rounds">JUDGING ROUNDS:</h2>
 </div>
@@ -1675,6 +1704,7 @@ the collection of entries are divided into two roughly equal piles;
 the pile that advances on to the next round, and the pile that does
 not. We also re-examine the entries that were eliminated in the
 previous round. Thus, a submission gets at least two readings.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="readings">
 <h2 id="judging-readings">JUDGING READINGS:</h2>
 </div>
@@ -1779,6 +1809,7 @@ a submission simply far exceeds any of the other entries. More often, the
 <p>In years past, we renamed the winning submission from <code>prog.c</code> to a
 name related to the author(s)’ names. This is no longer done.
 Winning source is called <code>prog.c</code>. A compiled binary is called <code>prog</code>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="announcements">
 <h1 id="announcement-of-winners">ANNOUNCEMENT OF WINNERS:</h1>
 </div>
@@ -1792,6 +1823,7 @@ We recommend that you follow us on mastodon but <strong>please make sure to
 refresh the feed</strong> every so often (if not more often) because unless you are
 mentioned or someone boosts your post you will not get a push notification.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="winners">
 <h2 id="how-the-new-ioccc-winners-will-be-announced">How the new IOCCC winners will be announced</h2>
 </div>
@@ -1819,6 +1851,7 @@ The <a href="../judges.html">IOCCC judges</a> will commit the winning source to 
 <p class="leftbar">
 The <a href="../news.html">IOCCC news</a> will also contain an announcement of the winners.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="mastodon">
 <h2 id="an-important-update-to-how-winners-are-announced">An important update to how winners are announced</h2>
 </div>
@@ -1831,6 +1864,7 @@ website</a>.
 <p class="leftbar">
 In addition a note is posted to the <a href="https://fosstodon.org/@ioccc">IOCCC Mastodon account</a>.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="entries">
 <h2 id="back-to-announcement-of-winners">Back to announcement of winners</h2>
 </div>
@@ -1844,6 +1878,7 @@ world. Winners have appeared in books (‘<code>The New Hacker's Dictionary</cod
 ‘<code>Obfuscated C and Other Mysteries</code>’, ‘<code>Pointers On C</code>’, others) and on t-shirts.
 More than one winner has been turned into a tattoo!</p>
 <p>Last, but not least, <a href="../authors.html">winners</a> receive international fame and flames! :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="more-information">
 <div id="information">
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
@@ -1874,6 +1909,7 @@ notification so you should make sure to check the page.
 <p class="leftbar">
 Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC website</a> in general.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <p>Leonid A. Broukhis<br>
 chongo (Landon Curt Noll) /\cc/\</p>
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -16,7 +16,6 @@ about these guidelines. You might also find the
 FAQ in general useful, especially the
 [FAQ section "How to enter: the bare minimum you need to know"](../faq.html#submit).
 
-
 # The IOCCC is closed
 
 The IOCCC is **NOT** accepting new submissions at this time.  See the
@@ -44,17 +43,19 @@ granted provided this this copyright and notice are included in its entirety
 and remains unaltered.  All other uses must receive prior permission in
 writing by [contacting the judges](../contact.html).
 
+Jump to: [top](#)
 
 <div id="guidelines_version">
 ## IOCCC Guidelines version
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.18 2024-10-21**.
+These [IOCCC guidelines](guidelines.html) are version **28.19 2024-10-25**.
 </p>
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
 
+Jump to: [top](#)
 
 <div id="change_marks">
 ### Change marks
@@ -68,6 +69,7 @@ Most lines (we sometimes make mistakes) that were modified since the previous
 IOCCC start with a solid 4 pixel black left border (or, in the case of a code
 block or blockquote, just a vertical bar).
 
+Jump to: [top](#)
 
 <div id="about_guidelines">
 # ABOUT THIS FILE:
@@ -88,6 +90,7 @@ guidelines](guidelines.html).
 entries**. The [rules](rules.html) are typically published along with the [IOCCC
 guidelines](guidelines.html)..
 
+Jump to: [top](#)
 
 <div id="new">
 # WHAT'S NEW THIS IOCCC
@@ -167,6 +170,7 @@ The IOCCC submission URL, [when the IOCCC is open](../status.html#open), is
 [submit.ioccc.org](https://submit.ioccc.org/).
 </p>
 
+Jump to: [top](#)
 
 <div id="hints">
 <div id="suggestions">
@@ -329,6 +333,9 @@ value similar to the [2001-2012](../faq.html#size_rule2001-2012) and
 [2013-2020](../faq.html#size_rule2013-2020) IOCCC eras.
 </p>
 
+
+Jump to: [top](#)
+
 <div id="mkiocccentry">
 ## `mkiocccentry`
 </div>
@@ -395,6 +402,8 @@ In many places it will prompt you to verify what you input, allowing you to
 correct details as you go along.
 </p>
 
+Jump to: [top](#)
+
 <div id="mkiocccentry-synopsis">
 ## `mkiocccentry(1)` synopsis
 </div>
@@ -426,6 +435,8 @@ for how to use this tool in more detail.
 Below are the tools that `mkiocccentry(1)` will run.
 </p>
 
+Jump to: [top](#)
+
 <div id="iocccsize">
 ## `iocccsize`
 </div>
@@ -435,6 +446,7 @@ detects a number of issues that you may ignore, if you wish, as described above.
 As we already discussed how to invoke this we will not include it here again.
 </p>
 
+Jump to: [top](#)
 
 <div id="chkentry">
 ## `chkentry`
@@ -473,6 +485,9 @@ and the
 FAQ on "[.info.json](../faq.html#info_json)"
 for much more information on these files.
 </p>
+
+
+Jump to: [top](#)
 
 <div id="txzchk">
 ## `txzchk`
@@ -522,6 +537,8 @@ manually package your submission tarball, you could still be violating [Rule
 See also the
 FAQ on "[txzchk](../faq.html#txzchk)".
 </p>
+
+Jump to: [top](#)
 
 <div id="fnamchk">
 ## `fnamchk`
@@ -754,6 +771,8 @@ use the `COTHER` Makefile variable.  For example:
 **NOTE**: **We only recommend using "_magic_" flags if _BOTH_ `gcc`
 _and_ `clang`** support it.
 </p>
+
+Jump to: [top](#)
 
 <div id="likes">
 <div id="dislikes">
@@ -1399,8 +1418,9 @@ character tab stop.
 <p class="leftbar">
 **PLEASE** observe our [IOCCC markdown guidelines](../markdown.html)
 when forming your submission's `remarks.md` file.  And if your submission
-contains additional markdown files, please follow those same guidelines.  See
-also [Rule 19](rules.html#rule19).
+contains additional markdown files, please follow those same guidelines for
+those files. See also [Rule 19](rules.html#rule19) and our
+FAQ on "[markdown](../faq.html#markdown)".
 </p>
 
 <p class="leftbar">
@@ -1414,6 +1434,7 @@ We **RECOMMEND** you put a reasonable amount effort into the content of the
 `remarks.md` file: it is a required for a reason.  :-)
 </p>
 
+Jump to: [top](#)
 
 <div id="rules_abuse">
 <div id="abusing_rules">
@@ -1482,6 +1503,7 @@ product management an even from customers themselves on a all too regular basis.
 This is one of the reasons why the [IOCCC rules](rules.html) and
 [IOCCC guidelines](guidelines.html) are written in obfuscated form.
 
+Jump to: [top](#)
 
 <div id="judging">
 # JUDGING PROCESS:
@@ -1551,6 +1573,8 @@ account](https://fosstodon.org/@ioccc).
 are mentioned you will NOT get a push notification!**
 </p>
 
+Jump to: [top](#)
+
 <div id="rounds">
 ## JUDGING ROUNDS:
 </div>
@@ -1560,6 +1584,8 @@ the collection of entries are divided into two roughly equal piles;
 the pile that advances on to the next round, and the pile that does
 not.  We also re-examine the entries that were eliminated in the
 previous round.  Thus, a submission gets at least two readings.
+
+Jump to: [top](#)
 
 <div id="readings">
 ## JUDGING READINGS:
@@ -1679,6 +1705,7 @@ In years past, we renamed the winning submission from `prog.c` to a
 name related to the author(s)' names.  This is no longer done.
 Winning source is called `prog.c`. A compiled binary is called `prog`.
 
+Jump to: [top](#)
 
 <div id="announcements">
 # ANNOUNCEMENT OF WINNERS:
@@ -1696,6 +1723,7 @@ refresh the feed** every so often (if not more often) because unless you are
 mentioned or someone boosts your post you will not get a push notification.
 </p>
 
+Jump to: [top](#)
 
 <div id="winners">
 ## How the new IOCCC winners will be announced
@@ -1731,6 +1759,7 @@ The [IOCCC judges](../judges.html) will commit the winning source to the
 The [IOCCC news](../news.html) will also contain an announcement of the winners.
 </p>
 
+Jump to: [top](#)
 
 <div id="mastodon">
 ## An important update to how winners are announced
@@ -1747,6 +1776,7 @@ website](https://www.ioccc.org/index.html).
 In addition a note is posted to the [IOCCC Mastodon account](https://fosstodon.org/@ioccc).
 </p>
 
+Jump to: [top](#)
 
 <div id="entries">
 ## Back to announcement of winners
@@ -1765,6 +1795,7 @@ More than one winner has been turned into a tattoo!
 
 Last, but not least, [winners](../authors.html) receive international fame and flames!  :-)
 
+Jump to: [top](#)
 
 <div id="more-information">
 <div id="information">
@@ -1802,6 +1833,8 @@ notification so you should make sure to check the page.
 <p class="leftbar">
 Check out the [Official IOCCC website](https://www.ioccc.org/index.html) in general.
 </p>
+
+Jump to: [top](#)
 
 Leonid A. Broukhis<br>
 chongo (Landon Curt Noll) /\\cc/\\

--- a/next/index.html
+++ b/next/index.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/next/rules.html
+++ b/next/rules.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="../thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="../next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="../SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="../faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="../faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="../faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="../contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="../inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="../authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="../location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="../faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="../thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="../news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="../status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="../news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="../SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="../faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="../faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="../faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="../about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="../thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="../bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="../inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -445,13 +458,16 @@ Copyright © 2024 Leonid A. Broukhis and Landon Curt Noll.
 granted provided this this copyright and notice are included in its entirety
 and remains unaltered. All other uses must receive prior permission in
 writing by <a href="../contact.html">contacting the judges</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rules_version">
 <h2 id="ioccc-rules-version">IOCCC Rules version</h2>
 </div>
+<p>Jump to: <a href="#">top</a></p>
 <p class="leftbar">
-These <a href="rules.html">IOCCC rules</a> are version <strong>28.9 2024-10-21</strong>.
+These <a href="rules.html">IOCCC rules</a> are version <strong>28.10 2024-10-25</strong>.
 </p>
 <p><strong>IMPORTANT</strong>: Be sure to read the <a href="guidelines.html">IOCCC guidelines</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="change_marks">
 <h3 id="change-marks">Change marks</h3>
 </div>
@@ -461,6 +477,7 @@ These <a href="rules.html">IOCCC rules</a> are version <strong>28.9 2024-10-21</
 <p>Most lines (we sometimes make mistakes) that were modified since the previous
 IOCCC start with a solid 4 pixel black left border (or, in the case of a code
 block or blockquote, just a vertical bar).</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="obfuscate">
 <h1 id="obfuscate-defined">Obfuscate defined:</h1>
 </div>
@@ -472,6 +489,7 @@ block or blockquote, just a vertical bar).</p>
 <strong>2.</strong> To confuse: his emotions obfuscated his judgment.<br>
     [LLat. obfuscare, to darken : ob(intensive) + Lat. fuscare,<br>
     to darken &lt; fuscus, dark.] -obfuscation n. obfuscatory adj.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="goals">
 <h1 id="goals-of-the-contest">Goals of the Contest</h1>
 </div>
@@ -483,6 +501,7 @@ block or blockquote, just a vertical bar).</p>
 <li>To illustrate some of the subtleties of the C language.</li>
 <li>To provide a safe forum for poor C code. :-)</li>
 </ul>
+<p>Jump to: <a href="#">top</a></p>
 <div id="dates">
 <h1 id="important-ioccc-dates">Important IOCCC dates</h1>
 </div>
@@ -519,22 +538,27 @@ FAQ on “<a href="../faq.html#mkiocccentry">obtaining and compiling the mkioccc
 tools</a>”
 and the
 FAQ on “<a href="../faq.html#submit">submitting to the IOCCC</a>”.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rules">
 <h1 id="ioccc-rules">IOCCC RULES</h1>
 </div>
 <p>To help us with the volume of submissions, we ask that you follow these rules:</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule0">
 <h2 id="rule-0">Rule 0</h2>
 </div>
 <p>We need a <a href="#rule0">rule 0</a>. :-)</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule1">
 <h2 id="rule-1">Rule 1</h2>
 </div>
 <p>Your submission must be a complete program.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule2">
 <h2 id="rule-2">Rule 2</h2>
 </div>
 <p>The size rule requires your submission to satisfy <strong>BOTH</strong> <a href="#rule2a">Rule 2a</a> and <a href="#rule2b">Rule 2b</a>:</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule2a">
 <h2 id="rule-2a">Rule 2a</h2>
 </div>
@@ -565,6 +589,7 @@ You may check your code prior to submission by giving the filename
 as a command like argument to the <code>iocccsize(1)</code> tool. For example:
 </p>
 <pre><code>    ./iocccsize prog.c</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule2b">
 <h2 id="rule-2b">Rule 2b</h2>
 </div>
@@ -599,6 +624,7 @@ You may check your code prior to submission by giving the filename
 as a command like argument to the <code>iocccsize(1)</code> tool. For example:
 </p>
 <pre><code>    ./iocccsize prog.c</code></pre>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule3">
 <h2 id="rule-3">Rule 3</h2>
 </div>
@@ -612,6 +638,7 @@ The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:
 <strong>XXX - date/time is TBD - XXX</strong>
 </p>
 <p><strong>Please wait to submit</strong> your entries until after that time.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule4">
 <h2 id="rule-4">Rule 4</h2>
 </div>
@@ -631,6 +658,7 @@ the files accordingly.
 <p class="leftbar">
 See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule5">
 <h2 id="rule-5">Rule 5</h2>
 </div>
@@ -640,6 +668,7 @@ original submission including, but not limited to <code>prog.c</code>, the <code
 files you submit.</p>
 <p>If you submission wishes to modify such content, it <strong>MUST</strong> first copy the
 file to a new filename and then modify that copy.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule6">
 <h2 id="rule-6">Rule 6</h2>
 </div>
@@ -651,6 +680,7 @@ I am not a rule, I am a <code>free(void *human);</code> ‼️
                 <code>ha_ha_ha();</code><br>
         <code>}</code>
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule7">
 <h2 id="rule-7">Rule 7</h2>
 </div>
@@ -665,6 +695,7 @@ under the following license:</p>
 detail that ownership</strong> (i.e., who owns what) <strong><em>AND</em> document the
 permission you obtained</strong>.</p>
 <p>Please note that the IOCCC size tool is <strong>NOT</strong> an original work.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule8">
 <h2 id="rule-8">Rule 8</h2>
 </div>
@@ -674,6 +705,7 @@ Entries must be received prior to the end of this IOCCC which is <strong>2024-MM
 </p>
 <p>A confirmation of submission will be sent to the submitting email address
 before the close of the contest.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule9">
 <h2 id="rule-9">Rule 9</h2>
 </div>
@@ -681,11 +713,13 @@ before the close of the contest.</p>
 Each person may submit up to and including <strong>10.000000</strong> (ten) entries per contest.
 </p>
 <p><strong>Each submission <em>must be submitted separately</em></strong>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule10">
 <h2 id="rule-10">Rule 10</h2>
 </div>
 <p>Entries requiring human interaction to be initially compiled <strong>are not
 permitted</strong>. However, see the <a href="guidelines.html">guidelines</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule11">
 <h2 id="rule-11">Rule 11</h2>
 </div>
@@ -695,6 +729,7 @@ DISCOURAGED</strong>. We do not guarantee these functions will behave as
 you expect on our test platforms. If your program needs special
 permissions you <strong>MUST</strong> document this fact, and explain why
 it is needed in your submissions <code>remarks.md</code> file.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule12">
 <h2 id="rule-12">Rule 12</h2>
 </div>
@@ -702,6 +737,7 @@ it is needed in your submissions <code>remarks.md</code> file.</p>
 the opinion of the <a href="../judges.html">judges</a>, violates the rules will be disqualified</strong>.
 Submissions that attempt to abuse the rules <strong>MUST</strong> try to justify why
 their rule abuse is legal, in the <code>remarks.md</code> file.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule13">
 <h2 id="rule-13">Rule 13</h2>
 </div>
@@ -709,6 +745,7 @@ their rule abuse is legal, in the <code>remarks.md</code> file.</p>
 Any C source that fails to compile because of unescaped octets with
 the high bit set (octet value &gt;= 128) <strong><em>might</em></strong> be rejected.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule14">
 <h2 id="rule-14">Rule 14</h2>
 </div>
@@ -719,6 +756,7 @@ control-M’s (i.e., lines with a tailing octet <code>015</code>) <strong><em>mi
 <p>Please do <strong>NOT</strong> put trailing control-M’s on remarks file lines.
 Please check to be sure, before submitting, that you have removed
 any control-M at the end of remark file lines.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule15">
 <h2 id="rule-15">Rule 15</h2>
 </div>
@@ -733,6 +771,7 @@ See the
 FAQ on “<a href="../faq.html#register">how to register</a>”
 for details.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule16">
 <h2 id="rule-16">Rule 16</h2>
 </div>
@@ -740,6 +779,7 @@ for details.
 original submission</strong>. Submissions that are similar to previous entries are
 discouraged. As we judge anonymously, submissions that have already
 been published may be disqualified.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule17">
 <h2 id="rule-17">Rule 17</h2>
 </div>
@@ -796,6 +836,7 @@ data file or some other JSON file.
 this rule! See the
 FAQ on “<a href="../faq.html#mkiocccentry">obtaining the mkiocccentry toolkit</a>”
 for more details.</p>
+<p>Jump to: <a href="#">top</a></p>
 <h3 id="rule-17---the-complex-details">Rule 17 - The COMPLEX details</h3>
 <p class="leftbar">
 Each submission <strong>MUST</strong> be in the form of a xz compressed tarball.
@@ -874,7 +915,8 @@ The <code>remarks.md</code> <strong>MUST</strong> be a <strong>non</strong>-empt
 <a href="#rule18">Rule 18</a> and our
 FAQ on “<a href="../faq.html#remarks_md">remarks.md</a>”
 and our
-FAQ on “<a href="../faq.html#markdown">markdown practices</a>”.
+FAQ on “<a href="../faq.html#markdown">markdown</a>”
+and our <a href="../markdown.html">markdown guidelines</a>.
 </p>
 <p class="leftbar">
 See also the <a href="https://www.markdownguide.org/basic-syntax">markdown syntax</a> guide
@@ -1012,6 +1054,7 @@ recent release without pulling or downloading via GitHub and <strong>make sure</
 do this <strong>AFTER</strong> the <a href="../status.html">contest status</a> has changed to
 <a href="../status.html#open">open</a>.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule18">
 <h2 id="rule-18">Rule 18</h2>
 </div>
@@ -1022,6 +1065,7 @@ do this <strong>AFTER</strong> the <a href="../status.html">contest status</a> h
 <p>You (the author(s)) <strong>MUST</strong> own the contents of your submission <strong>OR</strong>
 you <strong>MUST HAVE PERMISSION</strong> from the owner(s) to submit their content.</p>
 <p>You <strong>MUST NOT</strong> submit anything that cannot be submitted under that license.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule19">
 <h2 id="rule-19">Rule 19</h2>
 </div>
@@ -1037,6 +1081,7 @@ We currently use <a href="https://pandoc.org">pandoc</a> to convert markdown to 
 Please see our FAQ “<a href="../faq.html#remarks_md">remarks.md</a>” and the <a href="../markdown.html">IOCCC markdown
 guidelines</a> for additional markdown guidance.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule20">
 <h2 id="rule-20">Rule 20</h2>
 </div>
@@ -1065,6 +1110,7 @@ environments and systems that conform to the <a href="https://en.wikipedia.org/w
 Specification</a> are
 available in the <code>$PATH</code> search path.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule21">
 <h2 id="rule-21">Rule 21</h2>
 </div>
@@ -1073,6 +1119,7 @@ available in the <code>$PATH</code> search path.
 <strong>MAY</strong> create subdirectories below the current directory, or in <code>/tmp</code>,
 or in <code>/var/tmp</code> provided that <code>.</code> is <strong>NOT</strong> the first octet in any
 directory name or filename you create.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule22">
 <h2 id="rule-22">Rule 22</h2>
 </div>
@@ -1086,20 +1133,24 @@ within your code, data, remarks or program output (unless you are
 <strong>Peter Honeyman</strong> or pretending to be <strong>Peter Honeyman</strong>) will be grounds
 for disqualification of your submission.</p>
 <p>Yes, Virginia, <strong>WE REALLY MEAN IT!</strong></p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule23">
 <h2 id="rule-23">Rule 23</h2>
 </div>
 <p>This prime rule number is reserved for future use.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule24">
 <h2 id="rule-24">Rule 24</h2>
 </div>
 <p>Even though 24 is not prime, you should still see <a href="#rule23">Rule 23</a>.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule25">
 <h2 id="rule-25">Rule 25</h2>
 </div>
 <p class="leftbar">
 The <a href="rules.html">IOCCC rule set</a> needs more than 5^2 rules: see <a href="#rule26">Rule 26</a>.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule26">
 <h2 id="rule-26">Rule 26</h2>
 </div>
@@ -1112,12 +1163,14 @@ The <a href="rules.html">IOCCC rule set</a> needs more than 5^2 rules: see <a hr
 “Mr. Jock, TV quiz PhD, bags few lynx.”<br>
 “abcdefg, hijklmnop, qrstu&amp;v, wxy&amp;z.”</p>
 </blockquote>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule27">
 <h2 id="rule-27">Rule 27</h2>
 </div>
 <p class="leftbar">
 Unless otherwise needed, <a href="#rule27">Rule 27</a> is reserved for something cubic. :-)
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="rule28">
 <h2 id="rule-28">Rule 28</h2>
 </div>
@@ -1125,6 +1178,7 @@ Unless otherwise needed, <a href="#rule27">Rule 27</a> is reserved for something
 <a href="#rule28">Rule 28</a> is a perfect way end to the list of <a href="rules.html">IOCCC rules</a>
 as we do <strong>NOT</strong> plan to have <strong>496</strong> rules. :-)
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="more-information">
 <div id="information">
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
@@ -1154,6 +1208,7 @@ should refresh the page <strong>even if you do follow us</strong></em>.
 <p class="leftbar">
 Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.
 </p>
+<p>Jump to: <a href="#">top</a></p>
 <p><strong>Leonid A. Broukhis</strong><br>
 <strong>chongo (Landon Curt Noll) <code>/\cc/\</code></strong></p>
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/next/rules.md
+++ b/next/rules.md
@@ -46,17 +46,22 @@ granted provided this this copyright and notice are included in its entirety
 and remains unaltered.  All other uses must receive prior permission in
 writing by [contacting the judges](../contact.html).
 
+Jump to: [top](#)
 
 <div id="rules_version">
 ## IOCCC Rules version
 </div>
 
+Jump to: [top](#)
+
 <p class="leftbar">
-These [IOCCC rules](rules.html) are version **28.9 2024-10-21**.
+These [IOCCC rules](rules.html) are version **28.10 2024-10-25**.
 </p>
 
 **IMPORTANT**: Be sure to read the [IOCCC guidelines](guidelines.html).
 
+
+Jump to: [top](#)
 
 <div id="change_marks">
 ### Change marks
@@ -70,6 +75,7 @@ Most lines (we sometimes make mistakes) that were modified since the previous
 IOCCC start with a solid 4 pixel black left border (or, in the case of a code
 block or blockquote, just a vertical bar).
 
+Jump to: [top](#)
 
 <div id="obfuscate">
 # Obfuscate defined:
@@ -84,6 +90,7 @@ tr.v. -cated, -cating, -cates.
 &nbsp;&nbsp;&nbsp;&nbsp;[LLat. obfuscare, to darken : ob(intensive) + Lat. fuscare,<br>
 &nbsp;&nbsp;&nbsp;&nbsp;to darken &lt; fuscus, dark.] -obfuscation n. obfuscatory adj.
 
+Jump to: [top](#)
 
 <div id="goals">
 # Goals of the Contest
@@ -97,6 +104,7 @@ The goals of the IOCCC:
 *  To illustrate some of the subtleties of the C language.
 *  To provide a safe forum for poor C code. :-)
 
+Jump to: [top](#)
 
 <div id="dates">
 # Important IOCCC dates
@@ -144,6 +152,7 @@ tools](../faq.html#mkiocccentry)"
 and the
 FAQ on "[submitting to the IOCCC](../faq.html#submit)".
 
+Jump to: [top](#)
 
 <div id="rules">
 # IOCCC RULES
@@ -151,6 +160,7 @@ FAQ on "[submitting to the IOCCC](../faq.html#submit)".
 
 To help us with the volume of submissions, we ask that you follow these rules:
 
+Jump to: [top](#)
 
 <div id="rule0">
 ## Rule 0
@@ -158,6 +168,7 @@ To help us with the volume of submissions, we ask that you follow these rules:
 
 We need a [rule 0](#rule0).  :-)
 
+Jump to: [top](#)
 
 <div id="rule1">
 ## Rule 1
@@ -165,6 +176,7 @@ We need a [rule 0](#rule0).  :-)
 
 Your submission must be a complete program.
 
+Jump to: [top](#)
 
 <div id="rule2">
 ## Rule 2
@@ -172,6 +184,7 @@ Your submission must be a complete program.
 
 The size rule requires your submission to satisfy **BOTH** [Rule 2a](#rule2a) and [Rule 2b](#rule2b):
 
+Jump to: [top](#)
 
 <div id="rule2a">
 ## Rule 2a
@@ -212,6 +225,7 @@ as a command like argument to the `iocccsize(1)` tool. For example:
     ./iocccsize prog.c
 ```
 
+Jump to: [top](#)
 
 <div id="rule2b">
 ## Rule 2b
@@ -257,6 +271,8 @@ as a command like argument to the `iocccsize(1)` tool. For example:
     ./iocccsize prog.c
 ```
 
+Jump to: [top](#)
+
 <div id="rule3">
 ## Rule 3
 </div>
@@ -275,6 +291,7 @@ The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC
 
 **Please wait to submit** your entries until after that time.
 
+Jump to: [top](#)
 
 <div id="rule4">
 ## Rule 4
@@ -300,6 +317,7 @@ the files accordingly.
 See also [Rule 5](#rule5), [Rule 18](#rule18) and [Rule 21](#rule21).
 </p>
 
+Jump to: [top](#)
 
 <div id="rule5">
 ## Rule 5
@@ -313,6 +331,7 @@ files you submit.
 If you submission wishes to modify such content, it **MUST** first copy the
 file to a new filename and then modify that copy.
 
+Jump to: [top](#)
 
 <div id="rule6">
 ## Rule 6
@@ -328,6 +347,7 @@ I am not a rule, I am a `free(void *human);` ‼️
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`
 </p>
 
+Jump to: [top](#)
 
 <div id="rule7">
 ## Rule 7
@@ -349,6 +369,7 @@ permission you obtained**.
 
 Please note that the IOCCC size tool is **NOT** an original work.
 
+Jump to: [top](#)
 
 <div id="rule8">
 ## Rule 8
@@ -363,6 +384,7 @@ Entries must be received prior to the end of this IOCCC which is **2024-MMM-DD H
 A confirmation of submission will be sent to the submitting email address
 before the close of the contest.
 
+Jump to: [top](#)
 
 <div id="rule9">
 ## Rule 9
@@ -374,6 +396,7 @@ Each person may submit up to and including **10.000000** (ten) entries per conte
 
 **Each submission _must be submitted separately_**.
 
+Jump to: [top](#)
 
 <div id="rule10">
 ## Rule 10
@@ -382,6 +405,7 @@ Each person may submit up to and including **10.000000** (ten) entries per conte
 Entries requiring human interaction to be initially compiled **are not
 permitted**. However, see the [guidelines](guidelines.html).
 
+Jump to: [top](#)
 
 <div id="rule11">
 ## Rule 11
@@ -394,6 +418,7 @@ you expect on our test platforms. If your program needs special
 permissions you **MUST** document this fact, and explain why
 it is needed in your submissions `remarks.md` file.
 
+Jump to: [top](#)
 
 <div id="rule12">
 ## Rule 12
@@ -404,6 +429,7 @@ the opinion of the [judges](../judges.html), violates the rules will be disquali
 Submissions that attempt to abuse the rules **MUST** try to justify why
 their rule abuse is legal, in the `remarks.md` file.
 
+Jump to: [top](#)
 
 <div id="rule13">
 ## Rule 13
@@ -414,6 +440,7 @@ Any C source that fails to compile because of unescaped octets with
 the high bit set (octet value >= 128) **_might_** be rejected.
 </p>
 
+Jump to: [top](#)
 
 <div id="rule14">
 ## Rule 14
@@ -428,6 +455,7 @@ Please do **NOT** put trailing control-M's on remarks file lines.
 Please check to be sure, before submitting, that you have removed
 any control-M at the end of remark file lines.
 
+Jump to: [top](#)
 
 <div id="rule15">
 ## Rule 15
@@ -447,6 +475,8 @@ FAQ on "[how to register](../faq.html#register)"
 for details.
 </p>
 
+Jump to: [top](#)
+
 <div id="rule16">
 ## Rule 16
 </div>
@@ -456,6 +486,7 @@ original submission**. Submissions that are similar to previous entries are
 discouraged. As we judge anonymously, submissions that have already
 been published may be disqualified.
 
+Jump to: [top](#)
 
 <div id="rule17">
 ## Rule 17
@@ -510,6 +541,7 @@ this rule! See the
 FAQ on "[obtaining the mkiocccentry toolkit](../faq.html#mkiocccentry)"
 for more details.
 
+Jump to: [top](#)
 
 ### Rule 17 - The COMPLEX details
 
@@ -586,7 +618,8 @@ The `remarks.md` **MUST** be a **non**-empty file in markdown form.  See also
 [Rule 18](#rule18) and our
 FAQ on "[remarks.md](../faq.html#remarks_md)"
 and our
-FAQ on "[markdown practices](../faq.html#markdown)".
+FAQ on "[markdown](../faq.html#markdown)"
+and our [markdown guidelines](../markdown.html).
 </p>
 
 <p class="leftbar">
@@ -727,6 +760,7 @@ do this **AFTER** the [contest status](../status.html) has changed to
 [open](../status.html#open).
 </p>
 
+Jump to: [top](#)
 
 <div id="rule18">
 ## Rule 18
@@ -743,6 +777,7 @@ you **MUST HAVE PERMISSION** from the owner(s) to submit their content.
 
 You **MUST NOT** submit anything that cannot be submitted under that license.
 
+Jump to: [top](#)
 
 <div id="rule19">
 ## Rule 19
@@ -763,6 +798,7 @@ Please see our FAQ "[remarks.md](../faq.html#remarks_md)" and the [IOCCC markdow
 guidelines](../markdown.html) for additional markdown guidance.
 </p>
 
+Jump to: [top](#)
 
 <div id="rule20">
 ## Rule 20
@@ -800,6 +836,7 @@ Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification) are
 available in the `$PATH` search path.
 </p>
 
+Jump to: [top](#)
 
 <div id="rule21">
 ## Rule 21
@@ -811,6 +848,7 @@ _with the exception of_ the `/tmp` and the `/var/tmp` directories.  Your submiss
 or in `/var/tmp` provided that `.` is **NOT** the first octet in any
 directory name or filename you create.
 
+Jump to: [top](#)
 
 <div id="rule22">
 ## Rule 22
@@ -831,6 +869,7 @@ for disqualification of your submission.
 
 Yes, Virginia, **WE REALLY MEAN IT!**
 
+Jump to: [top](#)
 
 <div id="rule23">
 ## Rule 23
@@ -838,6 +877,7 @@ Yes, Virginia, **WE REALLY MEAN IT!**
 
 This prime rule number is reserved for future use.
 
+Jump to: [top](#)
 
 <div id="rule24">
 ## Rule 24
@@ -845,6 +885,7 @@ This prime rule number is reserved for future use.
 
 Even though 24 is not prime, you should still see [Rule 23](#rule23).
 
+Jump to: [top](#)
 
 <div id="rule25">
 ## Rule 25
@@ -854,6 +895,7 @@ Even though 24 is not prime, you should still see [Rule 23](#rule23).
 The [IOCCC rule set](rules.html) needs more than 5^2 rules: see [Rule 26](#rule26).
 </p>
 
+Jump to: [top](#)
 
 <div id="rule26">
 ## Rule 26
@@ -867,6 +909,7 @@ The [IOCCC rule set](rules.html) needs more than 5^2 rules: see [Rule 26](#rule2
 > "Mr. Jock, TV quiz PhD, bags few lynx."<br>
 > "abcdefg, hijklmnop, qrstu&v, wxy&z."
 
+Jump to: [top](#)
 
 <div id="rule27">
 ## Rule 27
@@ -876,6 +919,7 @@ The [IOCCC rule set](rules.html) needs more than 5^2 rules: see [Rule 26](#rule2
 Unless otherwise needed, [Rule 27](#rule27) is reserved for something cubic.  :-)
 </p>
 
+Jump to: [top](#)
 
 <div id="rule28">
 ## Rule 28
@@ -886,6 +930,7 @@ Unless otherwise needed, [Rule 27](#rule27) is reserved for something cubic.  :-
 as we do **NOT** plan to have **496** rules. :-)
 </p>
 
+Jump to: [top](#)
 
 <div id="more-information">
 <div id="information">
@@ -923,6 +968,7 @@ should refresh the page **even if you do follow us**_.
 Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
 </p>
 
+Jump to: [top](#)
 
 **Leonid A. Broukhis**<br>
 **chongo (Landon Curt Noll) `/\cc/\`**

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -414,35 +427,36 @@
 <h4 id="here-is-the-menu-you-missed-because-javascript-is-disabled">Here is the menu you missed because JavaScript is disabled:</h4>
 <h2 id="entries">Entries</h2>
 <ul>
-<li><a href="years.html">Winning Entries</a></li>
-<li><a href="authors.html">Winning Authors</a></li>
-<li><a href="location.html">Location of winning authors</a></li>
+<li><a href="years.html">Winning entries</a></li>
+<li><a href="authors.html">Winning authors</a></li>
+<li><a href="location.html">Location of authors</a></li>
 <li><a href="bugs.html">Bugs and (mis)features</a></li>
+<li><a href="faq.html#fix_an_entry">Fixing entries</a></li>
+<li><a href="faq.html#fix_author">Updating author info</a></li>
+<li><a href="thanks-for-help.html">Thanks for the help</a></li>
 </ul>
 <h2 id="status">Status</h2>
 <ul>
-<li><a href="news.html">IOCCC News</a></li>
+<li><a href="news.html">News</a></li>
 <li><a href="status.html">Contest status</a></li>
-<li><a href="next/index.html">Rules and Guidelines</a></li>
-<li><a href="markdown.html">IOCCC markdown</a></li>
+<li><a href="next/index.html">Rules and guidelines</a></li>
+<li><a href="markdown.html">Markdown guidelines</a></li>
+<li><a href="SECURITY.html">Security policy</a></li>
 </ul>
 <h2 id="faq">FAQ</h2>
 <ul>
-<li><a href="faq.html">FAQ</a></li>
-<li><a href="faq.html#submit">How to enter the IOCCC</a></li>
-<li><a href="faq.html#fix_an_entry">Fixing IOCCC entries</a></li>
-<li><a href="faq.html#fix_website">Fixing the website</a></li>
-<li><a href="faq.html#fix_author">Updating author info</a></li>
+<li><a href="faq.html">Frequently Asked Questions</a></li>
+<li><a href="faq.html#submit">How to enter</a></li>
+<li><a href="faq.html#compiling">Compiling entries</a></li>
+<li><a href="faq.html#running_entries">Running entries</a></li>
+<li><a href="faq.html#help">How to help</a></li>
 </ul>
 <h2 id="about">About</h2>
 <ul>
-<li><a href="index.html">IOCCC Home</a></li>
-<li><a href="contact.html">The IOCCC Judges</a></li>
-<li><a href="contact.html">Contacting the IOCCC</a></li>
-<li><a href="SECURITY.html">IOCCC Security Policy</a></li>
-<li><a href="thanks-for-help.html">Thanks for the help</a></li>
-<li><a href="bin/index.html">Website scripts</a></li>
-<li><a href="inc/index.html">Script include files</a>
+<li><a href="index.html">Home page</a></li>
+<li><a href="about.html">About the IOCCC</a></li>
+<li><a href="judges.html">The Judges</a></li>
+<li><a href="contact.html">Contact us</a>
 <!-- AFTER: last line of markdown file: nojs-menu.md --></li>
 </ul>
 

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -2,32 +2,33 @@
 
 ## Entries
 
-* [Winning Entries](years.html)
-* [Winning Authors](authors.html)
-* [Location of winning authors](location.html)
+* [Winning entries](years.html)
+* [Winning authors](authors.html)
+* [Location of authors](location.html)
 * [Bugs and &lpar;mis&rpar;features](bugs.html)
+* [Fixing entries](faq.html#fix_an_entry)
+* [Updating author info](faq.html#fix_author)
+* [Thanks for the help](thanks-for-help.html)
 
 ## Status
 
-* [IOCCC News](news.html)
+* [News](news.html)
 * [Contest status](status.html)
-* [Rules and Guidelines](next/index.html)
-* [IOCCC markdown](markdown.html)
+* [Rules and guidelines](next/index.html)
+* [Markdown guidelines](markdown.html)
+* [Security policy](SECURITY.html)
 
 ## FAQ
 
-* [FAQ](faq.html)
-* [How to enter the IOCCC](faq.html#submit)
-* [Fixing IOCCC entries](faq.html#fix_an_entry)
-* [Fixing the website](faq.html#fix_website)
-* [Updating author info](faq.html#fix_author)
+* [Frequently Asked Questions](faq.html)
+* [How to enter](faq.html#submit)
+* [Compiling entries](faq.html#compiling)
+* [Running entries](faq.html#running_entries)
+* [How to help](faq.html#help)
 
 ## About
 
-* [IOCCC Home](index.html)
-* [The IOCCC Judges](contact.html)
-* [Contacting the IOCCC](contact.html)
-* [IOCCC Security Policy](SECURITY.html)
-* [Thanks for the help](thanks-for-help.html)
-* [Website scripts](bin/index.html)
-* [Script include files](inc/index.html)
+* [Home page](index.html)
+* [About the IOCCC](about.html)
+* [The Judges](judges.html)
+* [Contact us](contact.html)

--- a/status.html
+++ b/status.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/years.html
+++ b/years.html
@@ -62,25 +62,43 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./years.html" class="sub-item-link">
-                Winning Entries
+                Winning entries
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./authors.html" class="sub-item-link">
-                Winning Authors
+                Winning authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./location.html" class="sub-item-link">
-                Location of winning authors
+                Location of authors
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./bugs.html" class="sub-item-link">
                 Bugs and (mis)features
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_an_entry" class="sub-item-link">
+                Fixing entries
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./faq.html#fix_author" class="sub-item-link">
+                Updating author info
+              </a>
+            </div>
+
+	    <div class="outfit-font">
+              <a href="./thanks-for-help.html" class="sub-item-link">
+                Thanks for the help
               </a>
             </div>
           </div>
@@ -94,7 +112,7 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./news.html" class="sub-item-link">
-                IOCCC News
+                News
               </a>
             </div>
 
@@ -106,15 +124,22 @@
 
             <div class="outfit-font">
               <a href="./next/index.html" class="sub-item-link">
-                Rules and Guidelines
+                Rules and guidelines
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./markdown.html" class="sub-item-link">
-                IOCCC Markdown Guidelines
+                Markdown guidelines
               </a>
             </div>
+
+            <div class="outfit-font">
+              <a href="./SECURITY.html" class="sub-item-link">
+                Security policy
+              </a>
+            </div>
+
           </div>
         </div>
 
@@ -126,33 +151,34 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./faq.html" class="sub-item-link">
-                  FAQ
+                  Frequently Asked Questions
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./faq.html#submit" class="sub-item-link">
-                How to enter the IOCCC
+                How to enter
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_an_entry" class="sub-item-link">
-                Fixing IOCCC entries
+              <a href="./faq.html#compiling" class="sub-item-link">
+                Compiling entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_website" class="sub-item-link">
-                Fixing the website
+              <a href="./faq.html#running_entries" class="sub-item-link">
+                Running entries
               </a>
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#fix_author" class="sub-item-link">
-                Updating author info
+              <a href="./faq.html#help" class="sub-item-link">
+                How to help
               </a>
             </div>
+
           </div>
         </div>
 
@@ -164,43 +190,25 @@
           <div class="sub-item">
             <div class="outfit-font">
               <a href="./index.html" class="sub-item-link">
-                IOCCC Home
+                Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="./about.html" class="sub-item-link">
+                About the IOCCC
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./judges.html" class="sub-item-link">
-                The IOCCC Judges
+                The Judges
               </a>
             </div>
 
             <div class="outfit-font">
               <a href="./contact.html" class="sub-item-link">
-                Contacting the IOCCC
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./SECURITY.html" class="sub-item-link">
-                IOCCC Security Policy
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./thanks-for-help.html" class="sub-item-link">
-                Thanks for the help
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./bin/index.html" class="sub-item-link">
-                Website scripts
-              </a>
-            </div>
-
-            <div class="outfit-font">
-              <a href="./inc/index.html" class="sub-item-link">
-                Script include files
+                Contact us
               </a>
             </div>
           </div>
@@ -242,11 +250,11 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./years.html">
-              Winning Entries
+              Winning entries
             </a>
 
             <a class="mobile-submenu-item" href="./authors.html">
-              Authors of winning IOCCC entries
+              Winning authors
             </a>
 
             <a class="mobile-submenu-item" href="./location.html">
@@ -257,6 +265,17 @@
               Bugs and (mis)features
             </a>
 
+            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
+              Fixing entries
+            </a>
+
+            <a class="mobile-submenu-item" href="./faq.html#fix_author">
+              Updating author info
+            </a>
+
+            <a class="mobile-submenu-item" href="./thanks-for-help.html">
+              Thanks for the help
+            </a>
           </div>
         </div>
 
@@ -267,22 +286,25 @@
           </div>
           <div class="mobile-submenu-wrapper">
 
+            <a class="mobile-submenu-item" href="./news.html">
+              News
+            </a>
+
             <a class="mobile-submenu-item" href="./status.html">
               Contest status
             </a>
 
             <a class="mobile-submenu-item" href="./next/index.html">
-              Rules and Guidelines
-            </a>
-
-            <a class="mobile-submenu-item" href="./news.html">
-              IOCCC News
+              Rules and guidelines
             </a>
 
             <a class="mobile-submenu-item" href="./markdown.html">
-              IOCCC Markdown Guidelines
+              Markdown guidelines
             </a>
 
+            <a class="mobile-submenu-item" href="./SECURITY.html">
+              Security policy
+            </a>
           </div>
         </div>
 
@@ -297,19 +319,19 @@
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter the IOCCC
+              How to enter
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_an_entry">
-              Fixing IOCCC entries
+            <a class="mobile-submenu-item" href="./faq.html#compiling">
+              Compiling entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_website">
-              Fixing the website
+            <a class="mobile-submenu-item" href="./faq.html#running_entries">
+              Running entries
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#fix_author">
-              Fixing author info
+            <a class="mobile-submenu-item" href="./faq.html#help">
+              How to help
             </a>
 
           </div>
@@ -322,31 +344,22 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="./index.html">
-              IOCCC Home
+              Home page
+            </a>
+
+            <a class="mobile-submenu-item" href="./about.html">
+              About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./judges.html">
-              The IOCCC Judges
+              The Judges
             </a>
 
             <a class="mobile-submenu-item" href="./contact.html">
-              Contacting the IOCCC
-            </a>
-
-            <a class="mobile-submenu-item" href="./thanks-for-help.html">
-              Thanks for the help
-            </a>
-
-            <a class="mobile-submenu-item" href="./bin/index.html">
-              Website scripts
-            </a>
-
-            <a class="mobile-submenu-item" href="./inc/index.html">
-              Script include files
+              Contact us
             </a>
           </div>
         </div>
-
       </div>
     </div>
   </div>


### PR DESCRIPTION

The sections have been modified a fair amount. The Entries menu has been
extended to have: Fixing entries, Updating author info, Thanks for the
help. The first two were moved from FAQ and the last one from About.  
The rationale for these, in order: entries and authors have to do with
entries and most of the help involves entries. It also has to do with
website but in 'about' it does not seem the right place, unless maybe it
is renamed to 'Credits' or something (I am not suggesting this one way
or the other). This one is debatable but that was the rationale.

The Status menu has been extended to have: Markdown guidelines and 
Security policy. The rationale is that the markdown guidelines are part
of contest guidelines and the security policy is about the status of the
entries and how if there are any security problems they will not be 
addressed (instead of about the IOCCC).

The FAQ was extended to have: Compiling entries, Running entries, How to 
help. The reason to not have compiling and running entries under Entries
is because this is 'how to' and also the menu was too long. How to help
seems like a good idea under FAQ too (was in About).

About was extended to have the new 'about.html' page (from about.md). 
This is a rare case where a new file is useful as it fits under 'About'.
The menu now is: Home page, About the IOCCC, The Judges, Contact us. I 
was pondering the 'About [the IOCCC]' at the top and also naming it
'About us' but it seemed like a link to index.html was necessary and as
for 'about us' it seemed less clear as to whether it was about the 
judges or the contest itself. The FAQ has been updated slightly for 
this.

After further inspection the bin/index.html and the inc/index.html links
were removed from the about section.

With these changes, renaming an item or slight reordering 
notwithstanding, I believe that #2006 is probably in good shape.