### PR TITLE
Fix .PHONY in top level Makefile

### DIFF
--- a/2001/westley/README.md
+++ b/2001/westley/README.md
@@ -15,7 +15,6 @@ code](#alternate-code) below.
 The current status of this entry is:
 
 > **STATUS: uses gets() - change to fgets() if possible**<br>
-> **STATUS: missing files - please provide them**<br>
 > **STATUS: main() has only one arg - try and make it have 2 or 3**
 
 For more detailed information see [2001/westley in bugs.html](../../bugs.html#2001_westley).

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -454,7 +454,6 @@ code</a> below.</p>
 <p>The current status of this entry is:</p>
 <blockquote>
 <p><strong>STATUS: uses gets() - change to fgets() if possible</strong><br>
-<strong>STATUS: missing files - please provide them</strong><br>
 <strong>STATUS: main() has only one arg - try and make it have 2 or 3</strong></p>
 </blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_westley">2001/westley in bugs.html</a>.</p>

--- a/Makefile
+++ b/Makefile
@@ -594,7 +594,7 @@ entry2csv:
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
 
-# mostly harmless tests
+# Mostly Harmless tests
 #
 test:
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
@@ -618,7 +618,7 @@ test:
 # Rules for building specific web pages - a subset of rules mentioned above
 ###########################################################################
 
-.PHONY: thanks bugs gen_next rules guidelines faq
+.PHONY: thanks bugs gen_next rules guidelines faq about contact markdown security
 
 # generate about.html
 #

--- a/bugs.html
+++ b/bugs.html
@@ -2260,10 +2260,6 @@ first so that you can compare the output. Make sure to recreate the extra files
 as described by the author if you do fix this. This might be looked at later if
 nobody else takes up the challenge.</p>
 <p>Jump to: <a href="#">top</a></p>
-<h3 id="status-missing-files---please-provide-them-2">STATUS: missing files - please provide them</h3>
-<p>The author referred to a file <code>card.gif</code> but this file is missing. Do you have
-it? Please provide it!</p>
-<p>Jump to: <a href="#">top</a></p>
 <div id="2001_williams">
 <h2 id="williams">2001/williams</h2>
 </div>

--- a/bugs.md
+++ b/bugs.md
@@ -2646,13 +2646,6 @@ nobody else takes up the challenge.
 
 Jump to: [top](#)
 
-### STATUS: missing files - please provide them
-
-The author referred to a file `card.gif` but this file is missing. Do you have
-it? Please provide it!
-
-Jump to: [top](#)
-
 <div id="2001_williams">
 ## 2001/williams
 </div>


### PR DESCRIPTION

For certain rules that build specific html files there was a missing 
.PHONY target.