### PR TITLE
Change website scripts to use jstrencode

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -802,10 +802,10 @@ For example:
     bin/jval-wrapper.sh -b -q 1984/mullender/.entry.json '$.manifest[2].inventory_order'
 
     bin/jval-wrapper.sh author/Anton_Algmyr.json '$.full_name'
-    bin/jval-wrapper.sh -q -T author/Anton_Algmyr.json '$.full_name' | jstrdecode -
+    bin/jval-wrapper.sh -q -T author/Anton_Algmyr.json '$.full_name' | jstrencode -
 ```
 
-**NOTE**: With `jstrdecode(1)` version 1.2.3 or better, one can use `jstrdecode -N`
+**NOTE**: With `jstrencode(1)` version 1.2.3 or better, one can use `jstrencode -N`
 and not have to use `-T` with `bin/jval-wrapper.sh`.
 
 

--- a/bin/entry2csv.sh
+++ b/bin/entry2csv.sh
@@ -146,21 +146,21 @@ if [[ -z $VERGE ]]; then
     exit 5
 fi
 #
-JSTRDECODE=$(type -P jstrdecode)
-export JSTRDECODE
-if [[ -z $JSTRDECODE ]]; then
-    echo "$0: FATAL: jstrdecode is not installed or not in \$PATH" 1>&2
-    echo "$0: notice: to install jstrdecode:" 1>&2
+JSTRENCODE=$(type -P jstrencode)
+export JSTRENCODE
+if [[ -z $JSTRENCODE ]]; then
+    echo "$0: FATAL: jstrencode is not installed or not in \$PATH" 1>&2
+    echo "$0: notice: to install jstrencode:" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
     exit 5
 fi
-export MIN_JSTRDECODE_VERSION="1.2.3"
-JSTRDECODE_VERSION=$("$JSTRDECODE" -V | head -1 | awk '{print $3;}')
-if ! "$VERGE" "$JSTRDECODE_VERSION" "$MIN_JSTRDECODE_VERSION"; then
-    echo "$0: FATAL: jstrdecode version: $JSTRDECODE_VERSION < minimum version: $MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: notice: consider updating jstrdecode from mkiocccentry repo" 1>&2
+export MIN_JSTRENCODE_VERSION="2.0.0"
+JSTRENCODE_VERSION=$("$JSTRENCODE" -V | head -1 | awk '{print $3;}')
+if ! "$VERGE" "$JSTRENCODE_VERSION" "$MIN_JSTRENCODE_VERSION"; then
+    echo "$0: FATAL: jstrencode version: $JSTRENCODE_VERSION < minimum version: $MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: notice: consider updating jstrencode from mkiocccentry repo" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
@@ -378,13 +378,13 @@ function output_abstract
     #
     PATTERN='$..abstract'
     if [[ $V_FLAG -ge 5 ]]; then
-	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N -" 1>&2
+	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N -" 1>&2
     fi
     export ABSTRACT
-    ABSTRACT=$("$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRDECODE" -N -)
+    ABSTRACT=$("$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRENCODE" -N -)
     status_codes=("${PIPESTATUS[@]}")
     if [[ ${status_codes[*]} =~ [1-9] || -z $ABSTRACT ]]; then
-	echo "$0: ERROR: in output_abstract: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N -  failed," \
+	echo "$0: ERROR: in output_abstract: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N -  failed," \
 	     "error codes: ${status_codes[*]}" 1>&2
 	return 5
     fi
@@ -660,9 +660,9 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: GIT_TOOL=$GIT_TOOL" 1>&2
     echo "$0: debug[3]: TOPDIR=$TOPDIR" 1>&2
     echo "$0: debug[3]: VERGE=$VERGE" 1>&2
-    echo "$0: debug[3]: JSTRDECODE=$JSTRDECODE" 1>&2
-    echo "$0: debug[3]: MIN_JSTRDECODE_VERSION=$MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: debug[3]: JSTRDECODE_VERSION=$JSTRDECODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE=$JSTRENCODE" 1>&2
+    echo "$0: debug[3]: MIN_JSTRENCODE_VERSION=$MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE_VERSION=$JSTRENCODE_VERSION" 1>&2
     echo "$0: debug[3]: NOOP=$NOOP" 1>&2
     echo "$0: debug[3]: DO_NOT_PROCESS=$DO_NOT_PROCESS" 1>&2
     echo "$0: debug[3]: EXIT_CODE=$EXIT_CODE" 1>&2

--- a/bin/gen-authors.sh
+++ b/bin/gen-authors.sh
@@ -126,21 +126,21 @@ if [[ -z $VERGE ]]; then
     exit 5
 fi
 #
-JSTRDECODE=$(type -P jstrdecode)
-export JSTRDECODE
-if [[ -z $JSTRDECODE ]]; then
-    echo "$0: FATAL: jstrdecode is not installed or not in \$PATH" 1>&2
-    echo "$0: notice: to install jstrdecode:" 1>&2
+JSTRENCODE=$(type -P jstrencode)
+export JSTRENCODE
+if [[ -z $JSTRENCODE ]]; then
+    echo "$0: FATAL: jstrencode is not installed or not in \$PATH" 1>&2
+    echo "$0: notice: to install jstrencode:" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
     exit 5
 fi
-export MIN_JSTRDECODE_VERSION="1.2.3"
-JSTRDECODE_VERSION=$("$JSTRDECODE" -V | head -1 | awk '{print $3;}')
-if ! "$VERGE" "$JSTRDECODE_VERSION" "$MIN_JSTRDECODE_VERSION"; then
-    echo "$0: FATAL: jstrdecode version: $JSTRDECODE_VERSION < minimum version: $MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: notice: consider updating jstrdecode from mkiocccentry repo" 1>&2
+export MIN_JSTRENCODE_VERSION="2.0.0"
+JSTRENCODE_VERSION=$("$JSTRENCODE" -V | head -1 | awk '{print $3;}')
+if ! "$VERGE" "$JSTRENCODE_VERSION" "$MIN_JSTRENCODE_VERSION"; then
+    echo "$0: FATAL: jstrencode version: $JSTRENCODE_VERSION < minimum version: $MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: notice: consider updating jstrencode from mkiocccentry repo" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
@@ -283,12 +283,12 @@ function output_award
     #
     PATTERN='$..award'
     if [[ $V_FLAG -ge 5 ]]; then
-	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N -" 1>&2
+	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N -" 1>&2
     fi
-    "$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRDECODE" -N -
+    "$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRENCODE" -N -
     status_codes=("${PIPESTATUS[@]}")
     if [[ ${status_codes[*]} =~ [1-9] ]]; then
-	echo "$0: ERROR: in output_award: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N - failed," \
+	echo "$0: ERROR: in output_award: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N - failed," \
 	     "error codes: ${status_codes[*]}" 1>&2
 	return 5
     fi
@@ -556,9 +556,9 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: GIT_TOOL=$GIT_TOOL" 1>&2
     echo "$0: debug[3]: TOPDIR=$TOPDIR" 1>&2
     echo "$0: debug[3]: VERGE=$VERGE" 1>&2
-    echo "$0: debug[3]: JSTRDECODE=$JSTRDECODE" 1>&2
-    echo "$0: debug[3]: MIN_JSTRDECODE_VERSION=$MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: debug[3]: JSTRDECODE_VERSION=$JSTRDECODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE=$JSTRENCODE" 1>&2
+    echo "$0: debug[3]: MIN_JSTRENCODE_VERSION=$MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE_VERSION=$JSTRENCODE_VERSION" 1>&2
     echo "$0: debug[3]: DOCROOT_SLASH=$DOCROOT_SLASH" 1>&2
     echo "$0: debug[3]: TAGLINE=$TAGLINE" 1>&2
     echo "$0: debug[3]: MD2HTML_SH=$MD2HTML_SH" 1>&2
@@ -746,7 +746,7 @@ EOF
 	    echo '<hr style="width:10%;text-align:left;margin-left:0">'
 	    echo
 	    if [[ $V_FLAG -ge 1 ]]; then
-		echo "$0: debug[1]: Processing author_handles that begin with $l for: $AUTHORS_HTML" 1>&2
+		echo "$0: debug[1]: Processing author_handles that begin with \"$l\" for: $AUTHORS_HTML" 1>&2
 	    fi
 
 	# case: we have a "sort_word file" line
@@ -795,7 +795,7 @@ EOF
 		#
 		case "$NAME" in
 		full_name)
-		    FULL_NAME=$("$JSTRDECODE" "$VALUE")
+		    FULL_NAME=$("$JSTRENCODE" "$VALUE")
 		    ;;
 		location_code)
 		    LOCATION_CODE="$VALUE"
@@ -816,7 +816,7 @@ EOF
 		    AUTHOR_GITHUB="$VALUE"
 		    ;;
 		affiliation)
-		    AUTHOR_AFFILIATION=$("$JSTRDECODE" "$VALUE")
+		    AUTHOR_AFFILIATION=$("$JSTRENCODE" "$VALUE")
 		    ;;
 		author_handle)
 		    AUTHOR_HANDLE="$VALUE"

--- a/bin/gen-location.sh
+++ b/bin/gen-location.sh
@@ -113,21 +113,21 @@ if [[ -z $VERGE ]]; then
     exit 5
 fi
 #
-JSTRDECODE=$(type -P jstrdecode)
-export JSTRDECODE
-if [[ -z $JSTRDECODE ]]; then
-    echo "$0: FATAL: jstrdecode is not installed or not in \$PATH" 1>&2
-    echo "$0: notice: to install jstrdecode:" 1>&2
+JSTRENCODE=$(type -P jstrencode)
+export JSTRENCODE
+if [[ -z $JSTRENCODE ]]; then
+    echo "$0: FATAL: jstrencode is not installed or not in \$PATH" 1>&2
+    echo "$0: notice: to install jstrencode:" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
     exit 5
 fi
-export MIN_JSTRDECODE_VERSION="1.2.3"
-JSTRDECODE_VERSION=$("$JSTRDECODE" -V | head -1 | awk '{print $3;}')
-if ! "$VERGE" "$JSTRDECODE_VERSION" "$MIN_JSTRDECODE_VERSION"; then
-    echo "$0: FATAL: jstrdecode version: $JSTRDECODE_VERSION < minimum version: $MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: notice: consider updating jstrdecode from mkiocccentry repo" 1>&2
+export MIN_JSTRENCODE_VERSION="2.0.0"
+JSTRENCODE_VERSION=$("$JSTRENCODE" -V | head -1 | awk '{print $3;}')
+if ! "$VERGE" "$JSTRENCODE_VERSION" "$MIN_JSTRENCODE_VERSION"; then
+    echo "$0: FATAL: jstrencode version: $JSTRENCODE_VERSION < minimum version: $MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: notice: consider updating jstrencode from mkiocccentry repo" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
@@ -441,9 +441,9 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: GIT_TOOL=$GIT_TOOL" 1>&2
     echo "$0: debug[3]: TOPDIR=$TOPDIR" 1>&2
     echo "$0: debug[3]: VERGE=$VERGE" 1>&2
-    echo "$0: debug[3]: JSTRDECODE=$JSTRDECODE" 1>&2
-    echo "$0: debug[3]: MIN_JSTRDECODE_VERSION=$MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: debug[3]: JSTRDECODE_VERSION=$JSTRDECODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE=$JSTRENCODE" 1>&2
+    echo "$0: debug[3]: MIN_JSTRENCODE_VERSION=$MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE_VERSION=$JSTRENCODE_VERSION" 1>&2
     echo "$0: debug[3]: DOCROOT_SLASH=$DOCROOT_SLASH" 1>&2
     echo "$0: debug[3]: TAGLINE=$TAGLINE" 1>&2
     echo "$0: debug[3]: MD2HTML_SH=$MD2HTML_SH" 1>&2
@@ -593,7 +593,7 @@ find "$AUTHOR_DIR" -mindepth 1 -maxdepth 1 -type f -name '*.json' -print |
 	# obtain the author full name
 	#
 	PATTERN='$..full_name'
-	FULL_NAME=$("$JVAL_WRAPPER" -b -q "$AUTHOR_HANDLE_JSON" "$PATTERN" | "$JSTRDECODE" -N -)
+	FULL_NAME=$("$JVAL_WRAPPER" -b -q "$AUTHOR_HANDLE_JSON" "$PATTERN" | "$JSTRENCODE" -N -)
 	status_codes=("${PIPESTATUS[@]}")
 	if [[ ${status_codes[*]} =~ [1-9] || -z $FULL_NAME ]]; then
 	    echo "$0: ERROR: cannot full name from: $AUTHOR_HANDLE" 1>&2

--- a/bin/gen-years.sh
+++ b/bin/gen-years.sh
@@ -116,21 +116,21 @@ if [[ -z $VERGE ]]; then
     exit 5
 fi
 #
-JSTRDECODE=$(type -P jstrdecode)
-export JSTRDECODE
-if [[ -z $JSTRDECODE ]]; then
-    echo "$0: FATAL: jstrdecode is not installed or not in \$PATH" 1>&2
-    echo "$0: notice: to install jstrdecode:" 1>&2
+JSTRENCODE=$(type -P jstrencode)
+export JSTRENCODE
+if [[ -z $JSTRENCODE ]]; then
+    echo "$0: FATAL: jstrencode is not installed or not in \$PATH" 1>&2
+    echo "$0: notice: to install jstrencode:" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
     exit 5
 fi
-export MIN_JSTRDECODE_VERSION="1.2.3"
-JSTRDECODE_VERSION=$("$JSTRDECODE" -V | head -1 | awk '{print $3;}')
-if ! "$VERGE" "$JSTRDECODE_VERSION" "$MIN_JSTRDECODE_VERSION"; then
-    echo "$0: FATAL: jstrdecode version: $JSTRDECODE_VERSION < minimum version: $MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: notice: consider updating jstrdecode from mkiocccentry repo" 1>&2
+export MIN_JSTRENCODE_VERSION="2.0.0"
+JSTRENCODE_VERSION=$("$JSTRENCODE" -V | head -1 | awk '{print $3;}')
+if ! "$VERGE" "$JSTRENCODE_VERSION" "$MIN_JSTRENCODE_VERSION"; then
+    echo "$0: FATAL: jstrencode version: $JSTRENCODE_VERSION < minimum version: $MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: notice: consider updating jstrencode from mkiocccentry repo" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
@@ -247,7 +247,7 @@ function output_award
     # obtain the award string
     #
     PATTERN='$..award'
-    AWARD_STRING=$("$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRDECODE" -N -)
+    AWARD_STRING=$("$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRENCODE" -N -)
     status_codes=("${PIPESTATUS[@]}")
     if [[ ${status_codes[*]} =~ [1-9] || -z $AWARD_STRING ]]; then
 	echo "$0: ERROR: in output_award: no award found in .entry.json file: $ENTRY_JSON_PATH" 1>&2
@@ -596,9 +596,9 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: GIT_TOOL=$GIT_TOOL" 1>&2
     echo "$0: debug[3]: TOPDIR=$TOPDIR" 1>&2
     echo "$0: debug[3]: VERGE=$VERGE" 1>&2
-    echo "$0: debug[3]: JSTRDECODE=$JSTRDECODE" 1>&2
-    echo "$0: debug[3]: MIN_JSTRDECODE_VERSION=$MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: debug[3]: JSTRDECODE_VERSION=$JSTRDECODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE=$JSTRENCODE" 1>&2
+    echo "$0: debug[3]: MIN_JSTRENCODE_VERSION=$MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE_VERSION=$JSTRENCODE_VERSION" 1>&2
     echo "$0: debug[3]: TAC_TOOL=$TAC_TOOL" 1>&2
     echo "$0: debug[3]: FMT_TOOL=$FMT_TOOL" 1>&2
     echo "$0: debug[3]: DOCROOT_SLASH=$DOCROOT_SLASH" 1>&2

--- a/bin/index.html
+++ b/bin/index.html
@@ -889,8 +889,8 @@ or if not found, the <code>JSONPath.sh(1)</code> tool from the recently forked a
     bin/jval-wrapper.sh -b -q 1984/mullender/.entry.json &#39;$.manifest[2].inventory_order&#39;
 
     bin/jval-wrapper.sh author/Anton_Algmyr.json &#39;$.full_name&#39;
-    bin/jval-wrapper.sh -q -T author/Anton_Algmyr.json &#39;$.full_name&#39; | jstrdecode -</code></pre>
-<p><strong>NOTE</strong>: With <code>jstrdecode(1)</code> version 1.2.3 or better, one can use <code>jstrdecode -N</code>
+    bin/jval-wrapper.sh -q -T author/Anton_Algmyr.json &#39;$.full_name&#39; | jstrencode -</code></pre>
+<p><strong>NOTE</strong>: With <code>jstrencode(1)</code> version 1.2.3 or better, one can use <code>jstrencode -N</code>
 and not have to use <code>-T</code> with <code>bin/jval-wrapper.sh</code>.</p>
 <div id="manifest-csv-entry">
 <h3 id="manifest.csv.entry.awk"><a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/bin/manifest.csv.entry.awk">manifest.csv.entry.awk</a></h3>

--- a/bin/jfmt-wrapper.sh
+++ b/bin/jfmt-wrapper.sh
@@ -8,7 +8,7 @@
 # file into a canonical style.
 #
 # NOTE: As of 2024 Sep 10 the jprint(1) tool has not been written,
-#       so jfmt-wrapper.sh uses with the jsp tool from:
+#       so jfmt-wrapper.sh uses the jsp tool from:
 #
 #	    https://github.com/kjozsa/jsp
 #

--- a/bin/manifest.entry.json.awk
+++ b/bin/manifest.entry.json.awk
@@ -302,17 +302,17 @@ within_manifest_array == 1 && begin_manifest_element == 1 && NF >= 3 && $1 ~ /^"
 
     # so we can single quote the entry_text as a single string, we protect any single quotes within it
     #
-    jstrdecode_arg = entry_text;
-    gsub(/'/, "'\"'\"'", jstrdecode_arg);
+    jstrencode_arg = entry_text;
+    gsub(/'/, "'\"'\"'", jstrencode_arg);
 
-    # form the jstrdecode command
+    # form the jstrencode command
     #
-    if (jstrdecode_arg ~ /^".*"$/) {
-	jstrdecode_cmd = "jstrdecode -Q -- " "'" substr(jstrdecode_arg, 2, length(jstrdecode_arg)-2)  "'";
+    if (jstrencode_arg ~ /^".*"$/) {
+	jstrencode_cmd = "jstrencode -Q -- " "'" substr(jstrencode_arg, 2, length(jstrencode_arg)-2)  "'";
     } else {
-	jstrdecode_cmd = "jstrdecode -Q -- " "'" jstrdecode_arg "'";
+	jstrencode_cmd = "jstrencode -Q -- " "'" jstrencode_arg "'";
     }
-    jstrdecode_cmd = jstrdecode_cmd " 2>/dev/null; echo $?";
+    jstrencode_cmd = jstrencode_cmd " 2>/dev/null; echo $?";
 
     # JSON decode entry_text
     #
@@ -320,21 +320,21 @@ within_manifest_array == 1 && begin_manifest_element == 1 && NF >= 3 && $1 ~ /^"
     result = "";
     exit_code = 0;
     # process each pipe line
-    while ((jstrdecode_cmd | getline pipe_output) > 0) {
+    while ((jstrencode_cmd | getline pipe_output) > 0) {
 	if (numLines++ == 0) {
-	    # case: 1st line is from jstrdecode
+	    # case: 1st line is from jstrencode
 	    result = pipe_output;
 	} else {
-	    # case: 2nd/line line is the jstrdecode exit code
+	    # case: 2nd/line line is the jstrencode exit code
 	    exit_code = pipe_output;
 	}
     }
-    close(jstrdecode_cmd);
+    close(jstrencode_cmd);
 
-    # validate exit code from jstrdecode
+    # validate exit code from jstrencode
     #
     if (length(exit_code) == 0 || exit_code != 0) {
-	print "ERROR: unable to jstrdecode entry_text:", entry_text > "/dev/stderr";
+	print "ERROR: unable to jstrencode entry_text:", entry_text > "/dev/stderr";
 	exit 213;	# END section will output ERROR message about cannot JSON decode entry_text
     }
 

--- a/bin/output-index-author.sh
+++ b/bin/output-index-author.sh
@@ -132,21 +132,21 @@ if [[ -z $VERGE ]]; then
     exit 5
 fi
 #
-JSTRDECODE=$(type -P jstrdecode)
-export JSTRDECODE
-if [[ -z $JSTRDECODE ]]; then
-    echo "$0: FATAL: jstrdecode is not installed or not in \$PATH" 1>&2
-    echo "$0: notice: to install jstrdecode:" 1>&2
+JSTRENCODE=$(type -P jstrencode)
+export JSTRENCODE
+if [[ -z $JSTRENCODE ]]; then
+    echo "$0: FATAL: jstrencode is not installed or not in \$PATH" 1>&2
+    echo "$0: notice: to install jstrencode:" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
     exit 5
 fi
-export MIN_JSTRDECODE_VERSION="1.2.3"
-JSTRDECODE_VERSION=$("$JSTRDECODE" -V | head -1 | awk '{print $3;}')
-if ! "$VERGE" "$JSTRDECODE_VERSION" "$MIN_JSTRDECODE_VERSION"; then
-    echo "$0: FATAL: jstrdecode version: $JSTRDECODE_VERSION < minimum version: $MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: notice: consider updating jstrdecode from mkiocccentry repo" 1>&2
+export MIN_JSTRENCODE_VERSION="2.0.0"
+JSTRENCODE_VERSION=$("$JSTRENCODE" -V | head -1 | awk '{print $3;}')
+if ! "$VERGE" "$JSTRENCODE_VERSION" "$MIN_JSTRENCODE_VERSION"; then
+    echo "$0: FATAL: jstrencode version: $JSTRENCODE_VERSION < minimum version: $MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: notice: consider updating jstrencode from mkiocccentry repo" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
@@ -345,10 +345,10 @@ function output_full_name
     # extract Full Name from the author/author_handle.json file
     #
     PATTERN='$..full_name'
-    "$JVAL_WRAPPER" -b -q "$AUTHOR_HANDLE_JSON_PATH" "$PATTERN" | "$JSTRDECODE" -N -
+    "$JVAL_WRAPPER" -b -q "$AUTHOR_HANDLE_JSON_PATH" "$PATTERN" | "$JSTRENCODE" -N -
     status_codes=("${PIPESTATUS[@]}")
     if [[ ${status_codes[*]} =~ [1-9] ]]; then
-	echo  "$0: ERROR: in output_full_name: $JVAL_WRAPPER -b -q $AUTHOR_HANDLE_JSON_PATH '$PATTERN' | $JSTRDECODE -N - failed," \
+	echo  "$0: ERROR: in output_full_name: $JVAL_WRAPPER -b -q $AUTHOR_HANDLE_JSON_PATH '$PATTERN' | $JSTRENCODE -N - failed," \
 	      "error codes: ${status_codes[*]}" 1>&2
 	return 5
     fi
@@ -688,9 +688,9 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: GIT_TOOL=$GIT_TOOL" 1>&2
     echo "$0: debug[3]: TOPDIR=$TOPDIR" 1>&2
     echo "$0: debug[3]: VERGE=$VERGE" 1>&2
-    echo "$0: debug[3]: JSTRDECODE=$JSTRDECODE" 1>&2
-    echo "$0: debug[3]: MIN_JSTRDECODE_VERSION=$MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: debug[3]: JSTRDECODE_VERSION=$JSTRDECODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE=$JSTRENCODE" 1>&2
+    echo "$0: debug[3]: MIN_JSTRENCODE_VERSION=$MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE_VERSION=$JSTRENCODE_VERSION" 1>&2
     echo "$0: debug[3]: DOCROOT_SLASH=$DOCROOT_SLASH" 1>&2
     echo "$0: debug[3]: REPO_TOP_URL=$REPO_TOP_URL" 1>&2
     echo "$0: debug[3]: REPO_URL=$REPO_URL" 1>&2

--- a/bin/output-year-index.sh
+++ b/bin/output-year-index.sh
@@ -151,21 +151,21 @@ if [[ -z $VERGE ]]; then
     exit 5
 fi
 #
-JSTRDECODE=$(type -P jstrdecode)
-export JSTRDECODE
-if [[ -z $JSTRDECODE ]]; then
-    echo "$0: FATAL: jstrdecode is not installed or not in \$PATH" 1>&2
-    echo "$0: notice: to install jstrdecode:" 1>&2
+JSTRENCODE=$(type -P jstrencode)
+export JSTRENCODE
+if [[ -z $JSTRENCODE ]]; then
+    echo "$0: FATAL: jstrencode is not installed or not in \$PATH" 1>&2
+    echo "$0: notice: to install jstrencode:" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
     exit 5
 fi
-export MIN_JSTRDECODE_VERSION="1.2.3"
-JSTRDECODE_VERSION=$("$JSTRDECODE" -V | head -1 | awk '{print $3;}')
-if ! "$VERGE" "$JSTRDECODE_VERSION" "$MIN_JSTRDECODE_VERSION"; then
-    echo "$0: FATAL: jstrdecode version: $JSTRDECODE_VERSION < minimum version: $MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: notice: consider updating jstrdecode from mkiocccentry repo" 1>&2
+export MIN_JSTRENCODE_VERSION="2.0.0"
+JSTRENCODE_VERSION=$("$JSTRENCODE" -V | head -1 | awk '{print $3;}')
+if ! "$VERGE" "$JSTRENCODE_VERSION" "$MIN_JSTRENCODE_VERSION"; then
+    echo "$0: FATAL: jstrencode version: $JSTRENCODE_VERSION < minimum version: $MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: notice: consider updating jstrencode from mkiocccentry repo" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
@@ -259,12 +259,12 @@ function output_award
     #
     PATTERN='$..award'
     if [[ $V_FLAG -ge 5 ]]; then
-	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N -" 1>&2
+	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N -" 1>&2
     fi
-    "$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRDECODE" -N -
+    "$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRENCODE" -N -
     status_codes=("${PIPESTATUS[@]}")
     if [[ ${status_codes[*]} =~ [1-9] ]]; then
-	echo "$0: ERROR: in output_award: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N - failed," \
+	echo "$0: ERROR: in output_award: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N - failed," \
 	     "error codes: ${status_codes[*]}" 1>&2
 	return 5
     fi
@@ -586,9 +586,9 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: GIT_TOOL=$GIT_TOOL" 1>&2
     echo "$0: debug[3]: TOPDIR=$TOPDIR" 1>&2
     echo "$0: debug[3]: VERGE=$VERGE" 1>&2
-    echo "$0: debug[3]: JSTRDECODE=$JSTRDECODE" 1>&2
-    echo "$0: debug[3]: MIN_JSTRDECODE_VERSION=$MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: debug[3]: JSTRDECODE_VERSION=$JSTRDECODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE=$JSTRENCODE" 1>&2
+    echo "$0: debug[3]: MIN_JSTRENCODE_VERSION=$MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE_VERSION=$JSTRENCODE_VERSION" 1>&2
     echo "$0: debug[3]: DOCROOT_SLASH=$DOCROOT_SLASH" 1>&2
     echo "$0: debug[3]: REPO_TOP_URL=$REPO_TOP_URL" 1>&2
     echo "$0: debug[3]: REPO_URL=$REPO_URL" 1>&2

--- a/bin/subst.entry-index.sh
+++ b/bin/subst.entry-index.sh
@@ -134,21 +134,21 @@ if [[ -z $VERGE ]]; then
     exit 5
 fi
 #
-JSTRDECODE=$(type -P jstrdecode)
-export JSTRDECODE
-if [[ -z $JSTRDECODE ]]; then
-    echo "$0: FATAL: jstrdecode is not installed or not in \$PATH" 1>&2
-    echo "$0: notice: to install jstrdecode:" 1>&2
+JSTRENCODE=$(type -P jstrencode)
+export JSTRENCODE
+if [[ -z $JSTRENCODE ]]; then
+    echo "$0: FATAL: jstrencode is not installed or not in \$PATH" 1>&2
+    echo "$0: notice: to install jstrencode:" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
     exit 5
 fi
-export MIN_JSTRDECODE_VERSION="1.2.3"
-JSTRDECODE_VERSION=$("$JSTRDECODE" -V | head -1 | awk '{print $3;}')
-if ! "$VERGE" "$JSTRDECODE_VERSION" "$MIN_JSTRDECODE_VERSION"; then
-    echo "$0: FATAL: jstrdecode version: $JSTRDECODE_VERSION < minimum version: $MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: notice: consider updating jstrdecode from mkiocccentry repo" 1>&2
+export MIN_JSTRENCODE_VERSION="2.0.0"
+JSTRENCODE_VERSION=$("$JSTRENCODE" -V | head -1 | awk '{print $3;}')
+if ! "$VERGE" "$JSTRENCODE_VERSION" "$MIN_JSTRENCODE_VERSION"; then
+    echo "$0: FATAL: jstrencode version: $JSTRENCODE_VERSION < minimum version: $MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: notice: consider updating jstrencode from mkiocccentry repo" 1>&2
     echo "$0: notice: run: git clone https://github.com/ioccc-src/mkiocccentry.git" 1>&2
     echo "$0: notice: then: cd mkiocccentry && make clobber all" 1>&2
     echo "$0: notice: then: cd jparse && sudo make install clobber" 1>&2
@@ -239,12 +239,12 @@ function output_award
     #
     PATTERN='$..award'
     if [[ $V_FLAG -ge 5 ]]; then
-	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N -" 1>&2
+	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N -" 1>&2
     fi
-    "$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRDECODE" -N -
+    "$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRENCODE" -N -
     status_codes=("${PIPESTATUS[@]}")
     if [[ ${status_codes[*]} =~ [1-9] ]]; then
-	echo "$0: ERROR: in output_award: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N - failed," \
+	echo "$0: ERROR: in output_award: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N - failed," \
 	     "error codes: ${status_codes[*]}" 1>&2
 	return 5
     fi
@@ -290,12 +290,12 @@ function output_abstract
     #
     PATTERN='$..abstract'
     if [[ $V_FLAG -ge 5 ]]; then
-	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRDECODE -N -" 1>&2
+	echo  "$0: debug[5]: about to run: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN' | $JSTRENCODE -N -" 1>&2
     fi
-    "$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRDECODE" -N -
+    "$JVAL_WRAPPER" -b -q "$ENTRY_JSON_PATH" "$PATTERN" | "$JSTRENCODE" -N -
     status_codes=("${PIPESTATUS[@]}")
     if [[ ${status_codes[*]} =~ [1-9] ]]; then
-	echo "$0: ERROR: in output_abstract: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN | $JSTRDECODE -N - failed," \
+	echo "$0: ERROR: in output_abstract: $JVAL_WRAPPER -b -q -- $ENTRY_JSON_PATH '$PATTERN | $JSTRENCODE -N - failed," \
 	     "error codes: ${status_codes[*]}" 1>&2
 	return 5
     fi
@@ -596,9 +596,9 @@ if [[ $V_FLAG -ge 3 ]]; then
     echo "$0: debug[3]: GIT_TOOL=$GIT_TOOL" 1>&2
     echo "$0: debug[3]: TOPDIR=$TOPDIR" 1>&2
     echo "$0: debug[3]: VERGE=$VERGE" 1>&2
-    echo "$0: debug[3]: JSTRDECODE=$JSTRDECODE" 1>&2
-    echo "$0: debug[3]: MIN_JSTRDECODE_VERSION=$MIN_JSTRDECODE_VERSION" 1>&2
-    echo "$0: debug[3]: JSTRDECODE_VERSION=$JSTRDECODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE=$JSTRENCODE" 1>&2
+    echo "$0: debug[3]: MIN_JSTRENCODE_VERSION=$MIN_JSTRENCODE_VERSION" 1>&2
+    echo "$0: debug[3]: JSTRENCODE_VERSION=$JSTRENCODE_VERSION" 1>&2
     echo "$0: debug[3]: DOCROOT_SLASH=$DOCROOT_SLASH" 1>&2
     echo "$0: debug[3]: REPO_TOP_URL=$REPO_TOP_URL" 1>&2
     echo "$0: debug[3]: REPO_URL=$REPO_URL" 1>&2


### PR DESCRIPTION
After the swap in the jparse repo of jstrencode and jstrdecode, due to mix-up in terminology, originally in the mkiocccentry repo, the website tools that used jstrdecode now have to use jstrencode, with a minimum version of 2.0.0.

The scripts have been updated to do this. After doing a make install from the jparse repo I did a make www with no html files changed. Then doing the same thing after make install from the mkiocccentry/jparse directory, no changes were made either, indicating that all should be okay.

The bin/index.html was however modified to refer to jstrencode, not jstrdecode.