### PR TITLE
Address missing files in 2001/herrmann1

### DIFF
--- a/2001/herrmann1/README.md
+++ b/2001/herrmann1/README.md
@@ -9,7 +9,6 @@
 
 The current status of this entry is:
 
-> **STATUS: missing files - please provide them**<br>
 > **STATUS: known bug - please help us fix**
 
 For more detailed information see [2001/herrmann1 in bugs.html](../../bugs.html#2001_herrmann1).
@@ -81,7 +80,7 @@ terminal!
 
 #### For the impatient
 
-The info files `herrmann1.turing` and [herrmann1.gcd](%%REPO_URL%%/2001/herrmann1/herrmann1.gcd) are sample
+The info files `herrmann1.times2` and [herrmann1.gcd](%%REPO_URL%%/2001/herrmann1/herrmann1.gcd) are sample
 programs for the Turing machine. For example, type
 
 ``` <!---sh-->
@@ -121,11 +120,11 @@ result.)
 
 
 In the previous example, the Turing machine started on the default
-tape of the program `times2.turing`. To provide your own tape, type
+tape of the program `herrmann1.times2`. To provide your own tape, type
 (for example)
 
 ``` <!---sh-->
-    ./herrmann1 prg=times2.turing tape="O O O I I I O O O"
+    ./herrmann1 prg=herrmann1.times2 tape="O O O I I I O O O"
 ```
 
 (The `O`s and `I`s are letters, not digits.) You might prefer to

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -449,8 +449,7 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 <h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
 <p>The current status of this entry is:</p>
 <blockquote>
-<p><strong>STATUS: missing files - please provide them</strong><br>
-<strong>STATUS: known bug - please help us fix</strong></p>
+<p><strong>STATUS: known bug - please help us fix</strong></p>
 </blockquote>
 <p>For more detailed information see <a href="../../bugs.html#2001_herrmann1">2001/herrmann1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
@@ -496,7 +495,7 @@ terminal!</p></li>
 </ul>
 <h3 id="how-to-use-it">How to use it</h3>
 <h4 id="for-the-impatient">For the impatient</h4>
-<p>The info files <code>herrmann1.turing</code> and <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/herrmann1.gcd">herrmann1.gcd</a> are sample
+<p>The info files <code>herrmann1.times2</code> and <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/herrmann1.gcd">herrmann1.gcd</a> are sample
 programs for the Turing machine. For example, type</p>
 <pre><code>    ./herrmann1.sh &#39;prg=herrmann1.times2&#39;</code></pre>
 <p>and watch the animated Turing machine multiply 8 by two (in
@@ -521,9 +520,9 @@ type <code>./herrmann1</code> to see the final result. The output will be</p>
 <p>(Note that the last frame of the animation is <em>not</em> the final
 result.)</p>
 <p>In the previous example, the Turing machine started on the default
-tape of the program <code>times2.turing</code>. To provide your own tape, type
+tape of the program <code>herrmann1.times2</code>. To provide your own tape, type
 (for example)</p>
-<pre><code>    ./herrmann1 prg=times2.turing tape=&quot;O O O I I I O O O&quot;</code></pre>
+<pre><code>    ./herrmann1 prg=herrmann1.times2 tape=&quot;O O O I I I O O O&quot;</code></pre>
 <p>(The <code>O</code>s and <code>I</code>s are letters, not digits.) You might prefer to
 provide only a finite portion of the tape, like I did above. In
 this case, the remainder of the tape is filled with <code>O</code>s. ;-)</p>

--- a/bugs.html
+++ b/bugs.html
@@ -2166,12 +2166,6 @@ fixes there.</p>
 <h2 id="herrmann1">2001/herrmann1</h2>
 </div>
 <p>Jump to: <a href="#">top</a></p>
-<h3 id="status-missing-files---please-provide-them">STATUS: missing files - please provide them</h3>
-<h3 id="source-code-2001herrmann1herrmann1.c">Source code: <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2001/herrmann1/herrmann1.c">2001/herrmann1/herrmann1.c</a></h3>
-<h3 id="information-2001herrmann1index.html">Information: <a href="2001/herrmann1/index.html">2001/herrmann1/index.html</a></h3>
-<p>The author referred to the file <code>herrmann1.turing</code> but it does not exist not even
-in the archive. Do you have a copy? Please provide it!</p>
-<p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-7">STATUS: known bug - please help us fix</h3>
 <p>There is also a bug in part. During compilation you’re supposed to see some
 animation but this does not seem to work with modern gcc versions. It appears

--- a/bugs.html
+++ b/bugs.html
@@ -2167,10 +2167,10 @@ fixes there.</p>
 </div>
 <p>Jump to: <a href="#">top</a></p>
 <h3 id="status-known-bug---please-help-us-fix-7">STATUS: known bug - please help us fix</h3>
-<p>There is also a bug in part. During compilation you’re supposed to see some
-animation but this does not seem to work with modern gcc versions. It appears
-that version 2.95 works but maybe others do as well. Do you have a fix? We would
-appreciate your help!</p>
+<p>During compilation you’re supposed to see some animation but this does not seem
+to work with modern gcc versions. It appears that version 2.95 works but maybe
+others do as well. If you have a fix for modern versions of gcc, your help is
+welcome.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="2001_kev">
 <h2 id="kev">2001/kev</h2>

--- a/bugs.md
+++ b/bugs.md
@@ -2504,15 +2504,6 @@ Jump to: [top](#)
 
 Jump to: [top](#)
 
-### STATUS: missing files - please provide them
-### Source code: [2001/herrmann1/herrmann1.c](%%REPO_URL%%/2001/herrmann1/herrmann1.c)
-### Information: [2001/herrmann1/index.html](2001/herrmann1/index.html)
-
-The author referred to the file `herrmann1.turing` but it does not exist not even
-in the archive. Do you have a copy? Please provide it!
-
-Jump to: [top](#)
-
 ### STATUS: known bug - please help us fix
 
 There is also a bug in part. During compilation you're supposed to see some

--- a/bugs.md
+++ b/bugs.md
@@ -2506,10 +2506,10 @@ Jump to: [top](#)
 
 ### STATUS: known bug - please help us fix
 
-There is also a bug in part. During compilation you're supposed to see some
-animation but this does not seem to work with modern gcc versions. It appears
-that version 2.95 works but maybe others do as well. Do you have a fix? We would
-appreciate your help!
+During compilation you're supposed to see some animation but this does not seem
+to work with modern gcc versions. It appears that version 2.95 works but maybe
+others do as well. If you have a fix for modern versions of gcc, your help is
+welcome.
 
 Jump to: [top](#)
 


### PR DESCRIPTION
With thanks to Leo, the filenames have been corrected in the README.md/index.html file. As the manifest already has them (they were under different names) the .entry.json file did not have to be updated.