### PR TITLE
Fix html lint (W3C Nu) errors

### DIFF
--- a/1986/bright/.entry.json
+++ b/1986/bright/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "bright",
     "entry_id" : "1986_bright",
     "title" : "1986.bright",
-    "abstract" : "hex dump with cpp compressed that uses lots of << for constants",
+    "abstract" : "hex dump with cpp compressed that uses lots of `<<` for constants",
     "author_set" : [
         {
             "author_handle" : "Walter_Bright"

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1986/bright - Most useful obfuscation</h2>
-  <h3>hex dump with cpp compressed that uses lots of << for constants</h3>
+  <h3>hex dump with cpp compressed that uses lots of `<<` for constants</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/1988/litmaath/.entry.json
+++ b/1988/litmaath/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "litmaath",
     "entry_id" : "1988_litmaath",
     "title" : "1988.litmaath",
-    "abstract" : "sorts each arg using only argc argv and 'while(<cond>)'",
+    "abstract" : "sorts each arg using only argc argv and 'while(cond)'",
     "author_set" : [
         {
             "author_handle" : "Maarten_Litmaath"

--- a/1988/litmaath/index.html
+++ b/1988/litmaath/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1988/litmaath - Best small program</h2>
-  <h3>sorts each arg using only argc argv and 'while(<cond>)'</h3>
+  <h3>sorts each arg using only argc argv and 'while(cond)'</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/1992/albert/.entry.json
+++ b/1992/albert/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "albert",
     "entry_id" : "1992_albert",
     "title" : "1992.albert",
-    "abstract" : "factors multi-precision numbers with factors < MAX_LONG",
+    "abstract" : "factors multi-precision numbers with factors `< MAX_LONG`",
     "author_set" : [
         {
             "author_handle" : "Albert_van_der_Horst"

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1992/albert - Most useful program</h2>
-  <h3>factors multi-precision numbers with factors < MAX_LONG</h3>
+  <h3>factors multi-precision numbers with factors `< MAX_LONG`</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/2018/burton1/README.md
+++ b/2018/burton1/README.md
@@ -251,7 +251,7 @@ So which version is the shortest, portable hex dump?
 * 113 works on Ancient UNIX and the portable C compiler.
 * 119 works on all platforms, including the original Ritchie PDP-11 C compiler.
 
-### Coda:
+### Final remarks:
 
 Clearly, the smallest possible program violates modern best practice.
 It is not even possible to compile cleanly, but it will compile correctly.

--- a/2018/burton1/index.html
+++ b/2018/burton1/index.html
@@ -618,7 +618,7 @@ and efficient expression.</p>
 <li>113 works on Ancient UNIX and the portable C compiler.</li>
 <li>119 works on all platforms, including the original Ritchie PDP-11 C compiler.</li>
 </ul>
-<h3 id="coda">Coda:</h3>
+<h3 id="final-remarks">Final remarks:</h3>
 <p>Clearly, the smallest possible program violates modern best practice.
 It is not even possible to compile cleanly, but it will compile correctly.</p>
 <p>Included is <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton1/prog.alt.c">prog.alt.c</a>, a modern C implementation that is –

--- a/2018/burton2/README.md
+++ b/2018/burton2/README.md
@@ -391,7 +391,7 @@ Thus:
     cc -ansi -Wall -trigraphs -Wno-trigraphs -Wno-parentheses -Wno-empty-body -Wno-char-subscripts -Wno-pointer-sign -DU=O -DW=\"keywords\" -o prog prog.c
 ```
 
-### Coda:
+### Final remarks:
 
 [Cody Boone Ferguson](../../authors.html#Cody_Boone_Ferguson) was relentless in his pursuit of bugs.
 Thanks to his reports, the version of [unob.sh](%%REPO_URL%%/2018/burton2/unob.sh) is stronger,

--- a/2018/burton2/index.html
+++ b/2018/burton2/index.html
@@ -726,7 +726,7 @@ for obfuscation. Thus <code>-trigraphs -Wno-trigraphs</code> (which is also humo
 NB: This is <em>not</em> a portability concern, the one string holds only printable ASCII characters.</p>
 <p>Thus:</p>
 <pre><code>    cc -ansi -Wall -trigraphs -Wno-trigraphs -Wno-parentheses -Wno-empty-body -Wno-char-subscripts -Wno-pointer-sign -DU=O -DW=\&quot;keywords\&quot; -o prog prog.c</code></pre>
-<h3 id="coda">Coda:</h3>
+<h3 id="final-remarks">Final remarks:</h3>
 <p><a href="../../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a> was relentless in his pursuit of bugs.
 Thanks to his reports, the version of <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton2/unob.sh">unob.sh</a> is stronger,
 <code>tac</code> groks digraphs, <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2018/burton2/tokenfix.sh">tokenfix.sh</a> corrects for missing digraphs

--- a/2018/ferguson/README.md
+++ b/2018/ferguson/README.md
@@ -117,7 +117,7 @@ If you find yourself in an evolutionary dead end, try:
 0. Preface
 1. What it is
 2. How it works
-3. Hints (Keyboards, Options, Obfuscation, Example Invocations)
+3. Hints (Keyboards, Options, Easter egg, Example Invocations)
 4. Obfuscation (Techniques, Beauty)
 5. How to build (S and N Constants, Compilation, Portability, Installing)
 6. Final thoughts
@@ -558,13 +558,13 @@ are only parsed if the first character is `-` and if the parser hasn't seen
 the `-` - *in an earlier element of `argv`. This is not a bug!*
 
 
-<div id="obfuscation">
-### Obfuscation
+<div id="easter-egg">
+### Easter egg
 </div>
 
 Skip to [Example Invocations](#invocations).
 
-The Easter egg: Since Dawkins references the [Infinite Monkey Theorem][] it
+The Easter egg: since Dawkins references the [Infinite Monkey Theorem][] it
 simulates a monkey using a typewriter! This mode has the following changes:
 
 Selection is omitted; this means no sorting by fitness score (*each offspring

--- a/2018/ferguson/index.html
+++ b/2018/ferguson/index.html
@@ -513,7 +513,7 @@ while using more Cenozoic minded code migration, read <a href="rpm.html">rpm.htm
 <li>Preface</li>
 <li>What it is</li>
 <li>How it works</li>
-<li>Hints (Keyboards, Options, Obfuscation, Example Invocations)</li>
+<li>Hints (Keyboards, Options, Easter egg, Example Invocations)</li>
 <li>Obfuscation (Techniques, Beauty)</li>
 <li>How to build (S and N Constants, Compilation, Portability, Installing)</li>
 <li>Final thoughts</li>
@@ -825,9 +825,9 @@ itself) and then the target string would <em>literally</em> be set to <code>-r</
 it no longer cares about the <code>-</code> for option parsing. In other words options
 are only parsed if the first character is <code>-</code> and if the parser hasn’t seen
 the <code>-</code> - <em>in an earlier element of <code>argv</code>. This is not a bug!</em></p>
-<h3 id="obfuscation">Obfuscation</h3>
+<h3 id="easter-egg">Easter egg</h3>
 <p>Skip to <a href="#invocations">Example Invocations</a>.</p>
-<p>The Easter egg: Since Dawkins references the <a href="https://en.wikipedia.org/wiki/Infinite_monkey_theorem">Infinite Monkey Theorem</a> it
+<p>The Easter egg: since Dawkins references the <a href="https://en.wikipedia.org/wiki/Infinite_monkey_theorem">Infinite Monkey Theorem</a> it
 simulates a monkey using a typewriter! This mode has the following changes:</p>
 <p>Selection is omitted; this means no sorting by fitness score (<em>each offspring
 is initially set to be the first two in the list</em>) but do pseudo-randomly
@@ -1048,9 +1048,7 @@ invalid character (<code>'\n'</code> itself which means another line break) and 
 finally the closing <code>'</code>. Specifically <code>isspace()</code> characters aren’t
 distinctly seen like a letter, digit or symbol is: <code>isprint('\n') == 0 &amp;&amp; isspace('\n') == 1</code>. You can add these characters but the output will be
 rather confusing and hard to read.</p>
-<div id="obfuscation">
-<h2 id="obfuscation-1"><strong>4. Obfuscation</strong></h2>
-</div>
+<h2 id="obfuscation"><strong>4. Obfuscation</strong></h2>
 <h3 id="techniques">Techniques</h3>
 <p>Skip to <a href="#beauty">Beauty</a>.</p>
 <p>The following might be some of the techniques used in this entry:</p>

--- a/2020/ferguson1/terminals.html
+++ b/2020/ferguson1/terminals.html
@@ -568,7 +568,7 @@ even just the <code>reset</code> command.</p>
 <p>The Linux man page says:</p>
 <blockquote>
 <p>You might have to run the <code>reset</code> tool like:</p>
-<p><LF>reset<LF></p>
+<p><code>&lt;LF&gt;reset&lt;LF&gt;</code></p>
 <p>(the line-feed character is normally control-J) to get the terminal to work,
 as carriage-return may no longer work in the abnormal state.</p>
 </blockquote>

--- a/2020/ferguson1/terminals.md
+++ b/2020/ferguson1/terminals.md
@@ -193,7 +193,7 @@ The Linux man page says:
 
 > You might have to run the `reset` tool like:
 >
->   <LF>reset<LF>
+>   `<LF>reset<LF>`
 >
 >   (the line-feed character is normally control-J) to get the terminal to work,
 as carriage-return may no longer work in the abnormal state.


### PR DESCRIPTION
In the case of two which had an abstract (.entry.json file) that includes one (in one case) '<' or two (in another case) '<'s a markdown code block had to be used as otherwise the abstract would have to have a &lt; which looks even worse. This is not ideal but if we want it to pass lint this is what has to be done. Use of json \uxxxx won't work as that encodes it to < literally.

In the case of 2018/burton[12] the author had a section called Coda. This conflicted with the problem that all generated html files have such a section. To fix this problem I renamed it 'Final remarks'. Not ideal but at least it now passes as valid.

There were a number of different kinds of problems and in one case the symbols < and > could be fixed by changing it to a code block (which it should have been anyway) - that was 2020/ferguson1 I think.