### PR TITLE
Remove `s from .entry.json files

### DIFF
--- a/1986/bright/.entry.json
+++ b/1986/bright/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "bright",
     "entry_id" : "1986_bright",
     "title" : "1986.bright",
-    "abstract" : "hex dump with cpp compressed that uses lots of `<<` for constants",
+    "abstract" : "hex dump with cpp compressed that uses lots of << for constants",
     "author_set" : [
         {
             "author_handle" : "Walter_Bright"

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1986/bright - Most useful obfuscation</h2>
-  <h3>hex dump with cpp compressed that uses lots of `<<` for constants</h3>
+  <h3>hex dump with cpp compressed that uses lots of << for constants</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/1992/albert/.entry.json
+++ b/1992/albert/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "albert",
     "entry_id" : "1992_albert",
     "title" : "1992.albert",
-    "abstract" : "factors multi-precision numbers with factors `< MAX_LONG`",
+    "abstract" : "factors multi-precision numbers with factors < MAX_LONG",
     "author_set" : [
         {
             "author_handle" : "Albert_van_der_Horst"

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1992/albert - Most useful program</h2>
-  <h3>factors multi-precision numbers with factors `< MAX_LONG`</h3>
+  <h3>factors multi-precision numbers with factors < MAX_LONG</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->


### PR DESCRIPTION
The way the abstract is used for the index.html files does not allow for parsing by pandoc so it did not work as expected (I did not verify the two entries this is a problem).

The index.html files of these two entries have been modified. Unless the script is updated the only other way is to update the abstract to use &lt; but this can be discussed.