### PR TITLE
Fixes in html files in 1986/marshall

### DIFF
--- a/1986/marshall/README.md
+++ b/1986/marshall/README.md
@@ -8,12 +8,12 @@
 compilers and systems. See below and [compilers.html](compilers.html) for details.
 
 There is an [alternate version](#alternate-code). The reason is a funny problem:
-in modern systems, depending on the platform, compiler and the optimiser, it
-would work with one compiler with the optimiser but it would not work with the
-other; and if the optimiser state is changed the previous problematic compiler
-might work but the other one would not. We describe this in more detail in
-[compilers.html](compilers.html) and we encourage you to read it for entertainment
-if nothing else.
+in modern systems, depending on the platform, compiler and whether or not the
+optimiser is enabled, it might work with one compiler but non the other. But
+then if you swap the optimiser state the compiler that worked would no longer
+work and the compiler that did not work would. We describe this in more detail
+in [compilers.html](compilers.html) and we encourage you to read it for
+entertainment if nothing else.
 
 
 ## To use:
@@ -26,15 +26,16 @@ if nothing else.
 ## Alternate code:
 
 Due to the different [conflicting problems](compilers.html) with `gcc` and
-`clang`, we
-instead offer the problematic code as an alternate version whereas
-[marshall.c](%%REPO_URL%%/1986/marshall/marshall.c) has both the infinite loop and the complicated arg to
-`_exit()` commented out, changing the value passed into `_exit()` to `1`.
+`clang`, we offer the problematic code as an alternate version whereas
+[marshall.c](%%REPO_URL%%/1986/marshall/marshall.c) has both the loop (that
+turned into an infinite loop) commented out and the complicated arg to `_exit(2)`
+commented out, changing the value passed into `_exit()` to `1`.
 
 
 ### Alternate build:
 
-To see if your compiler has the problems noted:
+To see if your compiler has the problems noted above and in
+[compilers.html](compilers.html), first build the alternate code:
 
 
 ``` <!---sh-->
@@ -44,13 +45,15 @@ To see if your compiler has the problems noted:
 
 ### Alternate use:
 
+Once the alternate code is built, see if your compiler has the problem:
+
 ``` <!---sh-->
     ./marshall.alt
 ```
 
-Does it work in your system? That is does it not segfault, does it print it only
-once and does it not enter an infinite loop? Or more generally does it print the
-text exactly once and then exit?
+Does it work in your system? That is does it print the text only once and does
+it not enter an infinite loop? In other words, does it print the text _exactly
+once_ and then exit, without dumping core?
 
 
 ## Judges' remarks:

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -426,63 +426,67 @@
 
 <!-- BEFORE: 1st line of markdown file: 1986/marshall/compilers.md -->
 <h1 id="conflicting-compilers-and-optimisers-that-broke-this-entry-in-2023">Conflicting compilers and optimisers that broke this entry in 2023</h1>
-<p>As briefly noted in the <a href="index.html">index.html</a> <code>gcc</code> and <code>clang</code> caused different
-problems with this entry depending on the optimiser being enabled or not, where
-if the optimiser was enabled it would work with one compiler and not the other.
-But if you then disabled the optimiser the opposite problem would occur: the
-working compiler would no longer work and the non-functional one would start to
-work! And then there’s the problem of linux versus macOS causing problems.</p>
-<p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.alt.c">alternate code</a> (source code) demonstrates the problem so
-you can see if your compiler has the problem as described below.</p>
+<p>As briefly noted in the <a href="index.html">index.html</a> <code>gcc</code> versus <code>clang</code> caused
+different problems with this entry, depending on the optimiser being enabled or
+disabled, where if the optimiser was enabled it would work with one compiler but
+not the other; on the other hand, if you disabled the optimiser the opposite
+problem would occur: the working compiler would no longer work and the other one
+would! And then there’s the problem of linux versus macOS causing problems.</p>
+<p>Using the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.alt.c">alternate source code</a>
+demonstrates the problem so you can see if your compiler has the problem
+described below.</p>
 <p>In some versions of <code>gcc</code> and <code>clang</code> (this was first discovered in fedora linux 38)
-if the compiler was enabled one compiler would generate code that segfaulted but
-the other one would not. However, when then disabling the optimiser the compiler
-that had no problem suddenly did and the one that did suddenly did not. But
+if the optimiser was enabled one compiler would generate code that segfaulted but
+the other one did not. However, when disabling the optimiser, the compiler
+that had no problem suddenly <em>did</em> and the one that did suddenly <em>did not</em>. But
 segfaulting was not by any means the only problem.</p>
 <p>Another problem was that depending on the optimiser an infinite loop would be
 entered. But then removing it would cause other problems as well, including a
-segfault.</p>
+segfault!</p>
 <p>It was not only one compiler that dumped core. Both dumped core with other
-behaviour, depending on what changes in code were made and the optimiser being
-on or off. <code>Clang</code> in macOS also dumped core!</p>
+behaviour, depending on what changes in code were made, and the optimiser being
+on or off. <code>clang</code> in macOS also dumped core!</p>
 <p>The <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.c">marshall.c</a> has the original fix
-for <code>clang</code> which works with some compilers depending on the optimiser. When we
-refer to the code below we refer to the alternate code,
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.alt.c">marshall.alt.c</a>.</p>
+for <code>clang</code>, which works with some compilers, depending on the optimiser. Below
+we refer to the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.alt.c">alternate code
+marshall.alt.c</a>.</p>
 <h2 id="the-conflicting-compiler-problems">The conflicting compiler problems:</h2>
 <p>Below we describe the conflicting options that resulted in the need to modify
 the original code.</p>
 <h3 id="linux">Linux</h3>
-<p>With the optimiser disabled <code>GCC</code> compiled the code to enter an infinite loop.
-If the optimiser was enabled it worked fine. But if the optimiser is enabled
-<code>clang</code> generates code that first prints the text twice (it should print it once) and
-then immediately dumps core!</p>
-<p>But then there’s that infinite loop. What happens if we remove it?</p>
-<p>Once the loop is removed if we compile with <code>clang</code> and the optimiser is disabled
+<p>With the optimiser disabled <code>gcc</code> compiled the code to enter an infinite loop.
+If the optimiser was enabled it worked fine, but if the optimiser is enabled
+<code>clang</code> generates code that first prints the text twice (when it should print it
+only once) and then immediately dumps core!</p>
+<p>But then there’s that infinite loop. What happens if we fix it?</p>
+<p>Once the loop is removed, if we compile with <code>clang</code> and the optimiser is disabled
 all is okay. If however we compile with <code>gcc</code> and the optimiser is disabled the
 string is printed once and then the program dumps core! Why is this? It is
-because of the call to <code>_exit()</code> (see below).</p>
-<p><code>Clang</code> works fine with the loop removed and the optimiser disabled. If however we
-enable the optimiser <code>clang</code> will generate code that prints the string twice and
-dumps core just like before! What about the call to <code>_exit()</code>?</p>
-<p>The call was:</p>
+because of the call to the <code>_exit(2)</code> syscall (see below).</p>
+<p><code>clang</code> works fine with the loop removed if the optimiser is disabled. Once we
+enable it, though, it will generate code that prints the string twice and
+dumps core, just like before!</p>
+<div id="exit">
+<h3 id="what-about-the-call-to-the-_exit2-syscall">What about the call to the <code>_exit(2)</code> syscall?</h3>
+</div>
+<p>The call <em>was</em>:</p>
 <pre><code>    _exit(argv[(int)*argc-2/cc[1*(int)*argc]|-1&lt;&lt;4]);</code></pre>
-<p>Changing it to not refer to these variables and just exit 1 and the problems
-disappear!</p>
+<p>In the fixed code, these variables are simply commented out so the code does
+<code>_exit(1)</code>.</p>
 <h3 id="macos">macOS</h3>
-<p>But then there was macOS which had another problem!</p>
-<p>If the infinite loop is not removed/commented out and the optimiser is enabled
-it works fine but if it’s disabled it prints out the string and then enters an
-infinite loop!</p>
-<p>After we fix the infinite loop if we change the <code>_exit()</code> call in macOS and
-disable the optimiser we might get something like:</p>
+<p>Now as for macOS, <em>another problem</em> existed!</p>
+<p>If the code that resulted in an infinite loop is <em>NOT</em> commented out <em>AND</em> the
+optimiser is enabled it works fine; but if it [the optimiser] is disabled, it
+prints out the string and then enters that infinite loop!</p>
+<p>After we fix the infinite loop issue, if we change the call to the <code>_exit(2)</code>
+syscall in macOS and disable the optimiser we might get something like:</p>
 <pre><code>    $ ./marshall
           choo choo
     Segmentation fault: 11</code></pre>
 <p>Observe how it doesn’t print it twice. But of course it segfaults so it’s not
 right either.</p>
 <p>If the optimiser is enabled, however, we will see that it works fine before the
-change to <code>_exit()</code>.</p>
+change to the call to the <code>_exit(2)</code> syscall.</p>
 <h2 id="summary">Summary</h2>
 <p>And that is the tale of a little <del>engine</del> train that
 could…eventually! Or perhaps it’s the compilers, optimisers and OSes that

--- a/1986/marshall/compilers.md
+++ b/1986/marshall/compilers.md
@@ -1,33 +1,35 @@
 # Conflicting compilers and optimisers that broke this entry in 2023
 
-As briefly noted in the [index.html](index.html) `gcc` and `clang` caused different
-problems with this entry depending on the optimiser being enabled or not, where
-if the optimiser was enabled it would work with one compiler and not the other.
-But if you then disabled the optimiser the opposite problem would occur: the
-working compiler would no longer work and the non-functional one would start to
-work! And then there's the problem of linux versus macOS causing problems.
+As briefly noted in the [index.html](index.html) `gcc` versus `clang` caused
+different problems with this entry, depending on the optimiser being enabled or
+disabled, where if the optimiser was enabled it would work with one compiler but
+not the other; on the other hand, if you disabled the optimiser the opposite
+problem would occur: the working compiler would no longer work and the other one
+would! And then there's the problem of linux versus macOS causing problems.
 
-The [alternate code](%%REPO_URL%%/1986/marshall/marshall.alt.c) (source code) demonstrates the problem so
-you can see if your compiler has the problem as described below.
+Using the [alternate source code](%%REPO_URL%%/1986/marshall/marshall.alt.c)
+demonstrates the problem so you can see if your compiler has the problem
+described below.
 
 In some versions of `gcc` and `clang` (this was first discovered in fedora linux 38)
-if the compiler was enabled one compiler would generate code that segfaulted but
-the other one would not. However, when then disabling the optimiser the compiler
-that had no problem suddenly did and the one that did suddenly did not. But
+if the optimiser was enabled one compiler would generate code that segfaulted but
+the other one did not. However, when disabling the optimiser, the compiler
+that had no problem suddenly _did_ and the one that did suddenly _did not_. But
 segfaulting was not by any means the only problem.
 
 Another problem was that depending on the optimiser an infinite loop would be
 entered. But then removing it would cause other problems as well, including a
-segfault.
+segfault!
 
 It was not only one compiler that dumped core. Both dumped core with other
-behaviour, depending on what changes in code were made and the optimiser being
-on or off. `Clang` in macOS also dumped core!
+behaviour, depending on what changes in code were made, and the optimiser being
+on or off. `clang` in macOS also dumped core!
 
 The [marshall.c](%%REPO_URL%%/1986/marshall/marshall.c) has the original fix
-for `clang` which works with some compilers depending on the optimiser. When we
-refer to the code below we refer to the alternate code,
-[marshall.alt.c](%%REPO_URL%%/1986/marshall/marshall.alt.c).
+for `clang`, which works with some compilers, depending on the optimiser. Below
+we refer to the [alternate code
+marshall.alt.c](%%REPO_URL%%/1986/marshall/marshall.alt.c).
+
 
 ## The conflicting compiler problems:
 
@@ -36,42 +38,48 @@ the original code.
 
 ### Linux
 
-With the optimiser disabled `GCC` compiled the code to enter an infinite loop.
-If the optimiser was enabled it worked fine. But if the optimiser is enabled
-`clang` generates code that first prints the text twice (it should print it once) and
-then immediately dumps core!
+With the optimiser disabled `gcc` compiled the code to enter an infinite loop.
+If the optimiser was enabled it worked fine, but if the optimiser is enabled
+`clang` generates code that first prints the text twice (when it should print it
+only once) and then immediately dumps core!
 
-But then there's that infinite loop. What happens if we remove it?
+But then there's that infinite loop. What happens if we fix it?
 
-Once the loop is removed if we compile with `clang` and the optimiser is disabled
+Once the loop is removed, if we compile with `clang` and the optimiser is disabled
 all is okay. If however we compile with `gcc` and the optimiser is disabled the
 string is printed once and then the program dumps core! Why is this? It is
-because of the call to `_exit()` (see below).
+because of the call to the `_exit(2)` syscall (see below).
 
-`Clang` works fine with the loop removed and the optimiser disabled. If however we
-enable the optimiser `clang` will generate code that prints the string twice and
-dumps core just like before!  What about the call to `_exit()`?
+`clang` works fine with the loop removed if the optimiser is disabled. Once we
+enable it, though, it will generate code that prints the string twice and
+dumps core, just like before!
 
-The call was:
+
+<div id="exit">
+### What about the call to the `_exit(2)` syscall?
+</div>
+
+The call _was_:
 
 
 ``` <!---c-->
     _exit(argv[(int)*argc-2/cc[1*(int)*argc]|-1<<4]);
 ```
 
-Changing it to not refer to these variables and just exit 1 and the problems
-disappear!
+In the fixed code, these variables are simply commented out so the code does
+`_exit(1)`.
+
 
 ### macOS
 
-But then there was macOS which had another problem!
+Now as for macOS, _another problem_ existed!
 
-If the infinite loop is not removed/commented out and the optimiser is enabled
-it works fine but if it's disabled it prints out the string and then enters an
-infinite loop!
+If the code that resulted in an infinite loop is _NOT_ commented out _AND_ the
+optimiser is enabled it works fine; but if it [the optimiser] is disabled, it
+prints out the string and then enters that infinite loop!
 
-After we fix the infinite loop if we change the `_exit()` call in macOS and
-disable the optimiser we might get something like:
+After we fix the infinite loop issue, if we change the call to the `_exit(2)`
+syscall in macOS and disable the optimiser we might get something like:
 
 ``` <!---sh-->
     $ ./marshall
@@ -83,7 +91,8 @@ Observe how it doesn't print it twice. But of course it segfaults so it's not
 right either.
 
 If the optimiser is enabled, however, we will see that it works fine before the
-change to `_exit()`.
+change to the call to the `_exit(2)` syscall.
+
 
 ## Summary
 

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -449,28 +449,30 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p><strong>NOTE</strong>: we <strong>FORCE</strong> disable the optimiser due to a funny problem with different
 compilers and systems. See below and <a href="compilers.html">compilers.html</a> for details.</p>
 <p>There is an <a href="#alternate-code">alternate version</a>. The reason is a funny problem:
-in modern systems, depending on the platform, compiler and the optimiser, it
-would work with one compiler with the optimiser but it would not work with the
-other; and if the optimiser state is changed the previous problematic compiler
-might work but the other one would not. We describe this in more detail in
-<a href="compilers.html">compilers.html</a> and we encourage you to read it for entertainment
-if nothing else.</p>
+in modern systems, depending on the platform, compiler and whether or not the
+optimiser is enabled, it might work with one compiler but non the other. But
+then if you swap the optimiser state the compiler that worked would no longer
+work and the compiler that did not work would. We describe this in more detail
+in <a href="compilers.html">compilers.html</a> and we encourage you to read it for
+entertainment if nothing else.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./marshall</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>
 <p>Due to the different <a href="compilers.html">conflicting problems</a> with <code>gcc</code> and
-<code>clang</code>, we
-instead offer the problematic code as an alternate version whereas
-<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.c">marshall.c</a> has both the infinite loop and the complicated arg to
-<code>_exit()</code> commented out, changing the value passed into <code>_exit()</code> to <code>1</code>.</p>
+<code>clang</code>, we offer the problematic code as an alternate version whereas
+<a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1986/marshall/marshall.c">marshall.c</a> has both the loop (that
+turned into an infinite loop) commented out and the complicated arg to <code>_exit(2)</code>
+commented out, changing the value passed into <code>_exit()</code> to <code>1</code>.</p>
 <h3 id="alternate-build">Alternate build:</h3>
-<p>To see if your compiler has the problems noted:</p>
+<p>To see if your compiler has the problems noted above and in
+<a href="compilers.html">compilers.html</a>, first build the alternate code:</p>
 <pre><code>    make alt</code></pre>
 <h3 id="alternate-use">Alternate use:</h3>
+<p>Once the alternate code is built, see if your compiler has the problem:</p>
 <pre><code>    ./marshall.alt</code></pre>
-<p>Does it work in your system? That is does it not segfault, does it print it only
-once and does it not enter an infinite loop? Or more generally does it print the
-text exactly once and then exit?</p>
+<p>Does it work in your system? That is does it print the text only once and does
+it not enter an infinite loop? In other words, does it print the text <em>exactly
+once</em> and then exit, without dumping core?</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>This program prints the name of the picture. The layout is somewhat
 pretty though it is not the usual sort of output one would expect

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -5171,7 +5171,7 @@ helped improve the presentation of their fellow IOCCC entries.</p>
 Ferguson</a> who is responsible for many
 improvements and fixes, including entries that no longer worked
 and other important fixes, often <strong>EXTREMELY HARD</strong> (for certain
-definitions of ‘<em>HARD</em>’ :-) ), such as
+definitions of ‘<code>HARD</code>’ :-) ), such as
 <a href="thanks-for-help.html#1988_phillipps">1988/phillipps</a>,
 <a href="thanks-for-help.html#1992_vern">1992/vern</a>,
 <a href="thanks-for-help.html#2001_anonymous">2001/anonymous</a>,

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -7109,7 +7109,7 @@ We call out the extensive contributions of [Cody Boone
 Ferguson](authors.html#Cody_Boone_Ferguson) who is responsible for many
 improvements and fixes, including entries that no longer worked
 and other important fixes, often **EXTREMELY HARD** (for certain
-definitions of '_HARD_' :-) ), such as
+definitions of '`HARD`' :-) ), such as
 [1988/phillipps](thanks-for-help.html#1988_phillipps),
 [1992/vern](thanks-for-help.html#1992_vern),
 [2001/anonymous](thanks-for-help.html#2001_anonymous),


### PR DESCRIPTION
This includes the compilers.html and index.html file.

I also threw in a slight formatting change in the thanks file.