### PR TITLE
Fix version in FAQ

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -425,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.1.3 2024-10-25</strong>.</p>
+<p>This is FAQ version <strong>28.1.6 2024-12-05</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#submit">How can I enter the IOCCC?</a></li>

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **28.1.3 2024-10-25**.
+This is FAQ version **28.1.6 2024-12-05**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)


### PR DESCRIPTION
The question of why did it jump from

    28.1.3 2024-10-25

to

    28.1.6 2024-12-05

can be explained as such. There were three edits since the last version update so there should be three version updates. As for why 5 December 2024 when today is 6 December 2024: it's because the last update to the contents was yesterday, 5 December 2024, although I believe there could be some improvements (menu wise) for Makefile.example. This has to be looked into and if it is done the version will be bumped again.