### PR TITLE
Fix .gitignore for more vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@
 ._.DS_Store
 .auth.json
 .info.json
-.su[a-z]
-.*.sv[a-z]
-.*.sw[a-z]
-.sw[a-zA-Z0-9]
+.s[a-zA-Z][a-zA-Z0-9]
 .tmp.*
 /NOTES
 /archive/historic/[12][0-9][0-9][0-9]


### PR DESCRIPTION
Rather than have several globs for vim swap files it is now a single glob (explanation below):

    .s[a-zA-Z][a-zA-Z0-9]

I encountered another letter, 'v', after the '.s', and instead of having several globs the glob just has [a-zA-Z] followed by [a-zA-Z0-9]. I believe this new way should cover everything. I have not checked the vim source code so I don't know if numbers are necessary and I don't know if it ever (if there were an incredible amount of swap files which might indicate rather a problem with the tree on the user's system) has more than three characters but this should theoretically cover everything and it is not a problem as no files in this glob should ever be in the website and definitely not in an entry as txzchk(1) and chkentry(1) verify.