### PR TITLE
Fix in 2018/ciura/index.html

### DIFF
--- a/2018/ciura/README.md
+++ b/2018/ciura/README.md
@@ -12,7 +12,7 @@ below for more details.
 ## To use:
 
 ``` <!---sh-->
-    ./prog < text
+    ./prog < file
 ```
 
 

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -450,7 +450,7 @@ Location: <a href="../../location.html#PL">PL</a> - <em>Republic of Poland</em> 
 code</a> and the author’s remarks’ <a href="#remarks">remarks section</a>,
 below for more details.</p>
 <h2 id="to-use">To use:</h2>
-<pre><code>    ./prog &lt; text</code></pre>
+<pre><code>    ./prog &lt; file</code></pre>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>


### PR DESCRIPTION
The to use should refer to a file, not some text.