### PR TITLE
Update/improve two entries' abstracts

### DIFF
--- a/1985/sicherman/.entry.json
+++ b/1985/sicherman/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "sicherman",
     "entry_id" : "1985_sicherman",
     "title" : "1985.sicherman",
-    "abstract" : "rot13 with strange #defs that create comment headers etc.",
+    "abstract" : "rot13 w/strange #defines that create comment headers etc.",
     "author_set" : [
         {
             "author_handle" : "Col_G_L_Sicherman"

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1985/sicherman - Worst abuse of the C preprocessor</h2>
-  <h3>rot13 with strange #defs that create comment headers etc.</h3>
+  <h3>rot13 w/strange #defines that create comment headers etc.</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/1988/phillipps/.entry.json
+++ b/1988/phillipps/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "phillipps",
     "entry_id" : "1988_phillipps",
     "title" : "1988.phillipps",
-    "abstract" : "days of christmas heavily main() calling with tables",
+    "abstract" : "12 Days of Christmas recursive main() calls w/tables",
     "author_set" : [
         {
             "author_handle" : "Ian_Phillipps"

--- a/1988/phillipps/index.html
+++ b/1988/phillipps/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1988/phillipps - Least likely to compile successfully</h2>
-  <h3>days of christmas heavily main() calling with tables</h3>
+  <h3>12 Days of Christmas recursive main() calls w/tables</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/2018/ciura/README.md
+++ b/2018/ciura/README.md
@@ -12,7 +12,7 @@ below for more details.
 ## To use:
 
 ``` <!---sh-->
-    ./prog < text
+    ./prog < file
 ```
 
 

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -450,7 +450,7 @@ Location: <a href="../../location.html#PL">PL</a> - <em>Republic of Poland</em> 
 code</a> and the author’s remarks’ <a href="#remarks">remarks section</a>,
 below for more details.</p>
 <h2 id="to-use">To use:</h2>
-<pre><code>    ./prog &lt; text</code></pre>
+<pre><code>    ./prog &lt; file</code></pre>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>


### PR DESCRIPTION
     
1985/sicherman now has an abstract of: rot13 w/strange #defines that
create comment headers etc.

I note that this is longer than what I believe was what was desired.
However it is the same length as it was before, only that it now has #defines
 instead of #defs.
           
1988/phillipps has: 12 Days of Christmas recursive main() calls w/tables
instead of 'days of christmas heavily main() calling with tables'. The 
rewording was necessary to keep the length the same but to be more 
clear. I just remembered however, that to fix it for modern systems, a 
new function had to be added which is the recursive function, so it no 
longer is strictly true that it it is recursive main() calls. It might 
be better to keep it main(), however, as that was the original award. 
The difference here is that it is now a bit more correct in the output.