### PR TITLE
Various fixes and updates

### DIFF
--- a/1984/mullender/README.md
+++ b/1984/mullender/README.md
@@ -40,7 +40,7 @@ start over once it times out or if one hits a key.
 Note that the microseconds is argc and it uses `atoi()` which does NOT check for
 overflow!
 
-BTW: is there such a thing as too fast a CPU ? :-) Actually yes for certain code
+**BTW**: is there such a thing as too fast a CPU ? :-) Actually yes for certain code
 which is probably not as uncommon as you think :-).
 
 
@@ -114,7 +114,7 @@ couldn't!  :-)
 
 What happens if you hit enter after it writes a line of output?
 
-BTW: to this day, 2023, this remains one of my (Landon Curt Noll's) all time
+**BTW**: to this day, 2023, this remains one of my (Landon Curt Noll's) all time
 favorite entries!
 
 

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -474,7 +474,7 @@ is it required one to hit enter for it to print another line; the alternate code
 start over once it times out or if one hits a key.</p>
 <p>Note that the microseconds is argc and it uses <code>atoi()</code> which does NOT check for
 overflow!</p>
-<p>BTW: is there such a thing as too fast a CPU ? :-) Actually yes for certain code
+<p><strong>BTW</strong>: is there such a thing as too fast a CPU ? :-) Actually yes for certain code
 which is probably not as uncommon as you think :-).</p>
 <h2 id="try">Try:</h2>
 <pre><code>    ./mullender.alt
@@ -519,7 +519,7 @@ second word.</p>
 produce a message on the screen. Can you guess what is printed? We knew you
 couldn’t! :-)</p>
 <p>What happens if you hit enter after it writes a line of output?</p>
-<p>BTW: to this day, 2023, this remains one of my (Landon Curt Noll’s) all time
+<p><strong>BTW</strong>: to this day, 2023, this remains one of my (Landon Curt Noll’s) all time
 favorite entries!</p>
 <h3 id="gentab.c">gentab.c</h3>
 <p>In 2023 remarks were discovered from <a href="../../authors.html#Sjoerd_Mullender">Sjoerd

--- a/1985/shapiro/.entry.json
+++ b/1985/shapiro/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "shapiro",
     "entry_id" : "1985_shapiro",
     "title" : "1985.shapiro",
-    "abstract" : "two defines one 7-liner that results in a maze",
+    "abstract" : "two #defines one 7-liner that results in a maze",
     "author_set" : [
         {
             "author_handle" : "Carl_Shapiro"

--- a/1985/shapiro/index.html
+++ b/1985/shapiro/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1985/shapiro - Grand Prize - Most well rounded in confusion</h2>
-  <h3>two defines one 7-liner that results in a maze</h3>
+  <h3>two #defines one 7-liner that results in a maze</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/1991/ant/README.md
+++ b/1991/ant/README.md
@@ -67,7 +67,7 @@ input keys described above. See the author's remarks for the remaining commands.
 The author was kind enough to supply a list of references below,
 in case you are still confused after read the source!  :-)
 
-BTW: you've most likely heard the joke that if you want a pseudo-random string
+**BTW**: you've most likely heard the joke that if you want a pseudo-random string
 of characters you can put a user unfamiliar with vi(m) in a vi(m) session (in
 insert mode) and ask them to exit. Well in this case you're likely to have this
 problem if you ARE a vi(m) user! :-) ... especially if you don't read the

--- a/1991/ant/index.html
+++ b/1991/ant/index.html
@@ -479,7 +479,7 @@ input keys described above. See the author’s remarks for the remaining command
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>The author was kind enough to supply a list of references below,
 in case you are still confused after read the source! :-)</p>
-<p>BTW: you’ve most likely heard the joke that if you want a pseudo-random string
+<p><strong>BTW</strong>: you’ve most likely heard the joke that if you want a pseudo-random string
 of characters you can put a user unfamiliar with vi(m) in a vi(m) session (in
 insert mode) and ask them to exit. Well in this case you’re likely to have this
 problem if you ARE a vi(m) user! :-) … especially if you don’t read the

--- a/1994/shapiro/.entry.json
+++ b/1994/shapiro/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "shapiro",
     "entry_id" : "1994_shapiro",
     "title" : "1994.shapiro",
-    "abstract" : "print time of day on an tty",
+    "abstract" : "print time of day on a tty",
     "author_set" : [
         {
             "author_handle" : "Andrew_Shapiro"

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>1994/shapiro - Most well rounded obfuscation</h2>
-  <h3>print time of day on an tty</h3>
+  <h3>print time of day on a tty</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->

--- a/1998/schnitzi/README.md
+++ b/1998/schnitzi/README.md
@@ -60,7 +60,7 @@ have output which depends on anything?
 For hints on deciphering this, see below past the Author's remarks;
 they're a nice summary, but they leave the mystery intact.
 
-BTW: the author notes an incredible
+**BTW**: the author notes an incredible
 [lipogram](https://en.wikipedia.org/wiki/Lipogram) story called
 [Gadsby](https://www.gutenberg.org/cache/epub/47342/pg47342.txt) which has no
 letter `E` in the story. He did not note this but it has over `50000` (50

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -479,7 +479,7 @@ the fixes for modern systems although there are still no <code>if</code>s) behav
 have output which depends on anything?</p>
 <p>For hints on deciphering this, see below past the Author’s remarks;
 they’re a nice summary, but they leave the mystery intact.</p>
-<p>BTW: the author notes an incredible
+<p><strong>BTW</strong>: the author notes an incredible
 <a href="https://en.wikipedia.org/wiki/Lipogram">lipogram</a> story called
 <a href="https://www.gutenberg.org/cache/epub/47342/pg47342.txt">Gadsby</a> which has no
 letter <code>E</code> in the story. He did not note this but it has over <code>50000</code> (50

--- a/2001/dgbeards/README.md
+++ b/2001/dgbeards/README.md
@@ -65,7 +65,7 @@ Of particular interest is the author's decision that the program should
 crash if it loses.  I've played chess with a lot of people like that, and
 I appreciate the realism.
 
-BTW: if your goal is to lose and you do does that mean you win? :-) What does
+**BTW**: if your goal is to lose and you do does that mean you win? :-) What does
 winning mean in a game you're supposed to lose at?
 
 

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -476,7 +476,7 @@ the entry win? Because it’s <em>trying</em> to lose.</p>
 <p>Of particular interest is the author’s decision that the program should
 crash if it loses. I’ve played chess with a lot of people like that, and
 I appreciate the realism.</p>
-<p>BTW: if your goal is to lose and you do does that mean you win? :-) What does
+<p><strong>BTW</strong>: if your goal is to lose and you do does that mean you win? :-) What does
 winning mean in a game you’re supposed to lose at?</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <h3 id="faq">FAQ</h3>

--- a/2004/anonymous/README.md
+++ b/2004/anonymous/README.md
@@ -68,7 +68,7 @@ p.s. [Frodo](https://www.glyphweb.com/arda/f/frodobaggins.html) lives!
 
 ### An important aside :-)
 
-BTW: if you haven't read [The Lord of the
+**BTW**: if you haven't read [The Lord of the
 Rings](https://en.wikipedia.org/wiki/The_Lord_of_the_Rings) what are you waiting for? :-)
 You'll find out the source of the text above though you'll see that there are
 some circumflexes missing! That's okay though due to I/O of the entry and in

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -489,7 +489,7 @@ Hobbit</a>.</p>
 struck out and he became a Hobbit.</p>
 <p>p.s. <a href="https://www.glyphweb.com/arda/f/frodobaggins.html">Frodo</a> lives!</p>
 <h3 id="an-important-aside--">An important aside :-)</h3>
-<p>BTW: if you haven’t read <a href="https://en.wikipedia.org/wiki/The_Lord_of_the_Rings">The Lord of the
+<p><strong>BTW</strong>: if you haven’t read <a href="https://en.wikipedia.org/wiki/The_Lord_of_the_Rings">The Lord of the
 Rings</a> what are you waiting for? :-)
 You’ll find out the source of the text above though you’ll see that there are
 some circumflexes missing! That’s okay though due to I/O of the entry and in

--- a/2019/duble/README.md
+++ b/2019/duble/README.md
@@ -218,7 +218,7 @@ You may set it to the full size of your terminal window by typing:
     make clobber fullscreen
 ```
 
-IMPORTANT NOTES:
+**IMPORTANT NOTES**:
 
 *   **The program compiled with a given size will fail to reload a drawing file
     with a different size!**

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -571,7 +571,7 @@ inverse video mode, and movement escape codes, e.g. <code>xterm</code>, <code>g
 <p>The default size is the one of my xterm (see top of Makefile).
 You may set it to the full size of your terminal window by typing:</p>
 <pre><code>    make clobber fullscreen</code></pre>
-<p>IMPORTANT NOTES:</p>
+<p><strong>IMPORTANT NOTES</strong>:</p>
 <ul>
 <li><strong>The program compiled with a given size will fail to reload a drawing file
 with a different size!</strong></li>

--- a/2020/ferguson1/troubleshooting.html
+++ b/2020/ferguson1/troubleshooting.html
@@ -757,7 +757,7 @@ so that by setting the size to -1 it went to the max unsigned value):</p>
 <pre><code>    $ MAXSIZE=-1 ./prog
     memory error
     X:0/157 Y:0/42 S:3/18446744073709551614 B:0</code></pre>
-<p>BTW: there are two arrays that have to be <strong>MAXSIZE</strong> (technically + 1).</p>
+<p><strong>BTW</strong>: there are two arrays that have to be <strong>MAXSIZE</strong> (technically + 1).</p>
 <p>Is it possible that some value specified by the user could mess this up? I do
 not know but what I do know is that because it’s unsigned it can’t be negative;
 if the max size is 0 then the array size will be 1 but it won’t matter because

--- a/2020/ferguson1/troubleshooting.md
+++ b/2020/ferguson1/troubleshooting.md
@@ -450,7 +450,7 @@ so that by setting the size to -1 it went to the max unsigned value):
 ```
 
 
-BTW: there are two arrays that have to be **MAXSIZE** (technically + 1).
+**BTW**: there are two arrays that have to be **MAXSIZE** (technically + 1).
 
 Is it possible that some value specified by the user could mess this up? I do
 not know but what I do know is that because it's unsigned it can't be negative;

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -284,7 +284,7 @@ After that you can input the string and it'll go from there.
 #### Example run
 </div>
 
-BTW: There's a much more entertaining way to explore this entry. See
+**BTW**: There's a much more entertaining way to explore this entry. See
 [recode.html][] for more details. There's a secret message that one might like
 to decipher. These however show the general program as well as how to use the
 two winning entries of the [Morse
@@ -511,7 +511,7 @@ with the rotors).
 
 For more information see [recode.html][].
 
-BTW: If you need a reminder to go to the gym just do your Enigma ABCs and it
+**BTW**: If you need a reminder to go to the gym just do your Enigma ABCs and it
 should help you remember:
 
 ``` <!---sh-->

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -649,7 +649,7 @@ pairs</a>.</p>
 <div id="example">
 <h4 id="example-run">Example run</h4>
 </div>
-<p>BTW: There’s a much more entertaining way to explore this entry. See
+<p><strong>BTW</strong>: There’s a much more entertaining way to explore this entry. See
 <a href="recode.html">recode.html</a> for more details. There’s a secret message that one might like
 to decipher. These however show the general program as well as how to use the
 two winning entries of the <a href="https://en.wikipedia.org/wiki/Morse_code">Morse
@@ -810,7 +810,7 @@ same applies: in C 0-1 but in human it’s 1-2 (technically these were reflector
 the Enigma machine which I display by name in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/2020/ferguson2/recode.c">recode.c</a> just like
 with the rotors).</p>
 <p>For more information see <a href="recode.html">recode.html</a>.</p>
-<p>BTW: If you need a reminder to go to the gym just do your Enigma ABCs and it
+<p><strong>BTW</strong>: If you need a reminder to go to the gym just do your Enigma ABCs and it
 should help you remember:</p>
 <pre><code>    $ echo ABC | ./prog
     GYM

--- a/2020/ferguson2/recode.html
+++ b/2020/ferguson2/recode.html
@@ -914,7 +914,7 @@ think that I would give too much away? :)</p>
     4MU1MS3CA0KECHOLATBJSNPXVUFGZY
     4VW0SL1YB0IYJSLBECKTNAXGPUVHRF
     0MC4OH2CO1LATEUMBJCDFGHINOPRQS</code></pre>
-<p>BTW: what’s the middle of a list with even numbered items anyway?</p>
+<p><strong>BTW</strong>: what’s the middle of a list with even numbered items anyway?</p>
 <p>To help you out, though, this is how you might do the decrypting. Assuming that
 the key you wish to select is</p>
 <pre><code>    0EZ4PC1CC0PGTAQSOXWNMDRYKFUZEI</code></pre>

--- a/2020/ferguson2/recode.md
+++ b/2020/ferguson2/recode.md
@@ -637,7 +637,7 @@ think that I would give too much away? :)
     0MC4OH2CO1LATEUMBJCDFGHINOPRQS
 ```
 
-BTW: what's the middle of a list with even numbered items anyway?
+**BTW**: what's the middle of a list with even numbered items anyway?
 
 To help you out, though, this is how you might do the decrypting. Assuming that
 the key you wish to select is

--- a/Makefile
+++ b/Makefile
@@ -681,12 +681,14 @@ faq: ${GEN_TOP_HTML} faq.md
 	@echo "Perhaps the FAQ might help!"
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
-gen_next: ${GEN_TOP_HTML} next/README.md next/guidelines.md next/rules.md next/register.md
+gen_next: ${GEN_TOP_HTML} next/README.md next/guidelines.md next/rules.md next/register.md next/submit.md next/pw-change.md
 	@echo '=-=-=-=-= IOCCC begin make $@ =-=-=-=-='
 	${GEN_TOP_HTML} -v 1 next/README
 	${GEN_TOP_HTML} -v 1 next/guidelines
 	${GEN_TOP_HTML} -v 1 next/rules
 	${GEN_TOP_HTML} -v 1 next/register
+	${GEN_TOP_HTML} -v 1 next/submit
+	${GEN_TOP_HTML} -v 1 next/pw-change
 	@echo '=-=-=-=-= IOCCC complete make $@ =-=-=-=-='
 
 markdown: ${GEN_TOP_HTML} markdown.md

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -1883,7 +1883,7 @@ known as the “<strong>obfuscated Peter Honeyman paradox</strong>”. Should Pe
 actually submit to the IOCCC, he alone is excluded from the above, as we
 will likely believe it’s just another attempt at confusion. This <em>guideline</em> is
 known as the “<strong>Peter Honeyman is exempt</strong>” <em>guideline</em>.</p>
-<p>BTW: None of the entries claiming to be from Peter Honeyman have ever
+<p><strong>BTW</strong>: None of the entries claiming to be from Peter Honeyman have ever
 won an award. So it is theoretically possible that Peter Honeyman
 did submit to the IOCCC in the past. In the past, Peter had denied
 submitting anything to the IOCCC. Perhaps those entries were

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -1789,7 +1789,7 @@ actually submit to the IOCCC, he alone is excluded from the above, as we
 will likely believe it's just another attempt at confusion.  This _guideline_ is
 known as the "**Peter Honeyman is exempt**" _guideline_.
 
-BTW: None of the entries claiming to be from Peter Honeyman have ever
+**BTW**: None of the entries claiming to be from Peter Honeyman have ever
 won an award.  So it is theoretically possible that Peter Honeyman
 did submit to the IOCCC in the past.  In the past, Peter had denied
 submitting anything to the IOCCC.  Perhaps those entries were

--- a/next/register.html
+++ b/next/register.html
@@ -444,7 +444,7 @@ in order to register for the IOCCC.</p>
 <p><img src="../png/register.0_531x445-signup.png"
  alt="signup for a mailing list"
  width=531 height=445></p>
-<p>After clicking <strong>((Next &gt;&gt;))</strong>, you will be notified you will receive some email:</p>
+<p>After clicking <strong>((Next &gt;&gt;))</strong>, you will be notified that you will receive an email:</p>
 <p><img src="../png/register.1_633x163-verify.png"
  alt="verify your email notification"
  width=633 height=163></p>
@@ -453,25 +453,27 @@ in order to register for the IOCCC.</p>
 </div>
 <p>Look for an automated email message from the FreeLists List Manager (<em>ecartis@freelists.org</em>).</p>
 <p>The email message will have the subject:</p>
-<pre><code>    Subscription consent for &#39;ioccc28-reg&#39;</code></pre>
-<p><strong>NOTE</strong>: Be aware that your email service, application and/or Internet
-service provider may modify email subject lines. For example, some string
-may have been prepended or appended to the subject line. Be aware of
+<blockquote>
+<p>Subscription consent for ‘ioccc28-reg’</p>
+</blockquote>
+<p><strong>NOTE</strong>: Beware that your email service, application and/or Internet
+Service Provider (ISP) might modify email subject lines. For example, some string
+might have been prepended or appended to the subject line. Beware of
 this when you search for the Subscription consent” email.</p>
 <p><strong>NOTE</strong>: The “Subscription consent” email is usually sent by the FreeLists
 List Manager within a minute after clicking the <strong>((Next &gt;&gt;))</strong> button.
 If you don’t see the “Subscription consent” email, check your spam folder.</p>
-<p><strong>NOTE</strong>: If are having trouble receiving the “Subscription consent”
-email, <a href="../contact.html">Contact the IOCCC</a>, and you have tried
-several times, ask the <a href="../judges.html">IOCCC judges</a> for assistance.</p>
+<p><strong>NOTE</strong>: If are having trouble receiving the “Subscription consent” email, and
+you have tried a few times, <a href="../contact.html">Contact the IOCCC</a> to ask the
+<a href="../judges.html">IOCCC judges</a> for assistance.</p>
 <p>This email will contain a URL of the form:
 <code>https://www.freelists.org/v/ioccc28-reg/SOME-RANDOM-STUFF</code>.</p>
-<p>Click on that link.</p>
-<p><strong>NOTE</strong>: If you prefer to <strong>NOT</strong> click links in email, simply copy that
-URL from your “Subscription consent email” and paste it into your browser.</p>
+<p>Click on that link. The email might look the below:</p>
 <p><img src="../png/register.2_590x253-verify-email.png"
  alt="Subscription consent email"
  width=590 height=253></p>
+<p><strong>NOTE</strong>: If you prefer to <strong>NOT</strong> click links in email, simply copy that
+URL from your “Subscription consent email” and paste it into your browser. The</p>
 <div id="step_d">
 <h2 id="step-d-confirm-your-email-click">Step D: Confirm your email click</h2>
 </div>
@@ -480,19 +482,20 @@ URL from your “Subscription consent email” and paste it into your browser.</
  alt="confirm your email"
  width=428 height=205></p>
 <div id="step_e">
-<h2 id="step-e-content-and-verify">Step E: Content and Verify</h2>
+<h2 id="step-e-verify-you-have-read-the-mailing-list-polices-and-that-you-consent-to-receiving-emails">Step E: Verify you have read the mailing list polices and that you consent to receiving emails</h2>
 </div>
-<p>The FreeLists service that you verify that you:</p>
+<p>The FreeLists service requires that you verify that you:</p>
 <ul>
 <li>Have read, understand, and agree to their “<em>Terms of Service</em>”</li>
 <li>Have read, understand, and agree to their “<em>Privacy Policy</em>”</li>
 <li>Are the owner or authorized user of the email you registered</li>
 </ul>
-<p>Once you have done this by clicking the 3 checkboxes, the <strong>((Next &gt;&gt;))</strong> button.</p>
+<p>Once you have done this by clicking the 3 checkboxes, click the <strong>((Next &gt;&gt;))</strong>
+button:</p>
 <p><img src="../png/register.4_657x446-subscribe.png"
  alt="complete subscription"
  width=657 height=446></p>
-<p>After clicking <strong>((Next &gt;&gt;))</strong>, you will be notified you will receive some email:</p>
+<p>After clicking <strong>((Next &gt;&gt;))</strong>, you will be notified that you will receive an email:</p>
 <p><img src="../png/register.5_487x154-done.png"
  alt="registration is complete"
  width=487 height=154></p>
@@ -508,14 +511,15 @@ URL from your “Subscription consent email” and paste it into your browser.</
  width=414 height=657></p>
 <p><strong>NOTE</strong>: The “Welcome” email is usually sent by the FreeLists
 List Manager within a minute after clicking the <strong>((Next &gt;&gt;))</strong> button.
-If you don’t see the “Subscription consent” email, check your spam folder.</p>
-<p><strong>NOTE</strong>: If are having trouble receiving the “Welcome” email,
-<a href="../contact.html">Contact the IOCCC</a>, and if you have tried
-several times, ask the <a href="../judges.html">IOCCC judges</a> for assistance.</p>
+If you don’t see the “Welcome” email, check your spam folder.</p>
+<p><strong>NOTE</strong>: If are having trouble receiving the “Welcome” email, and you have
+tried several times,
+<a href="../contact.html">Contact the IOCCC</a> to ask the <a href="../judges.html">IOCCC judges</a>
+for assistance.</p>
 <div id="step_i">
 <h2 id="step-i-proceed-with-step-3">Step I: Proceed with step 3</h2>
 </div>
-<p>When the is <a href="../status.html#open">open</a>, proceed with
+<p>When the contest is <a href="../status.html#open">open</a>, proceed with
 <a href="../faq.html#step_3">Step 3: Wait for your submit server username and initial password</a>.</p>
 <div id="status_impact">
 <h1 id="how-the-contest-status-impacts-registration">How the contest status impacts registration</h1>
@@ -528,21 +532,22 @@ for news about the next IOCCC as you may register when the contest is <a href=".
 or <a href="../status.html#open">open</a>.</p>
 <h3 id="when-the-ioccc-status-is-pending">When the IOCCC status is <em>pending</em></h3>
 <p>While the contest is <strong><a href="../status.html#pending">PENDING</a></strong>,
-you may **register for contest*, however you will <strong>NOT</strong>
-receive your own email message containing your <a href="https:/submit.ioccc.org">IOCCC submit server</a>
+you may <strong>register for contest</strong>, however you will <strong>NOT</strong>
+receive an email message containing your <a href="https://submit.ioccc.org">IOCCC submit server</a>
 <strong>Username and Initial Password until the IOCCC is <a href="../status.html#open">open</a></strong>.</p>
 <h3 id="when-the-ioccc-status-is-open">When the IOCCC status is <em>open</em></h3>
 <p>While the contest is <strong><a href="../status.html#open">OPEN</a></strong>,
 you may <strong>register for the contest</strong>. Once you are registered <strong>AND</strong>
-the contest is <a href="../status.html#open">open</a>, you will receive your own email message containing your very own
+the contest is <a href="../status.html#open">open</a>, you will receive an email message containing your very own
 <strong>Username and Initial Password until the contest is <a href="../status.html#open">open</a></strong>. You will need these
-to be able to <a href="submit.html">upload your submission</a> to the <a href="https:/submit.ioccc.org">IOCCC submit server</a>.</p>
+to be able to <a href="submit.html">upload your submissions</a> to the <a href="https://submit.ioccc.org">IOCCC submit
+server</a>.</p>
 <p>See also the
-FAQ on “<a href="submit.html">how to upload your submission</a>”
+FAQ on “<a href="../faq.html#submit">how to upload your submission</a>”
 for more information on the submission process when the IOCCC <a href="../status.html#open">reopens</a>.</p>
 <h3 id="when-the-ioccc-status-is-judging">When the IOCCC status is <em>judging</em></h3>
 <p>While the contest is <strong><a href="../status.html#pending">PENDING</a></strong>,
-you <strong>CANNOT REGISTER</strong> as the current because the
+you <strong>CANNOT REGISTER</strong> because the
 <a href="../judges.html">IOCCC judges</a> are in the process of judging the <a href="../faq.html#how_many">submissions</a>
 they received while the contest was <a href="../status.html#open">open</a>.</p>
 <p>Watch the <a href="../news.html">IOCCC news</a> and the <a href="https://fosstodon.org/@ioccc">IOCCC Mastodon</a>

--- a/next/register.md
+++ b/next/register.md
@@ -26,7 +26,7 @@ For details see the "[How the contest status impacts registration](#status_impac
  alt="signup for a mailing list"
  width=531 height=445>
 
- After clicking **((Next >>))**, you will be notified you will receive some email:
+After clicking **((Next >>))**, you will be notified that you will receive an email:
 
 <img src="../png/register.1_633x163-verify.png"
  alt="verify your email notification"
@@ -41,34 +41,33 @@ Look for an automated email message from the FreeLists List Manager (_ecartis@fr
 
 The email message will have the subject:
 
-```
-    Subscription consent for 'ioccc28-reg'
-```
+> Subscription consent for 'ioccc28-reg'
 
-**NOTE**: Be aware that your email service, application and/or Internet
-service provider may modify email subject lines.  For example, some string
-may have been prepended or appended to the subject line.  Be aware of
+**NOTE**: Beware that your email service, application and/or Internet
+Service Provider (ISP) might modify email subject lines.  For example, some string
+might have been prepended or appended to the subject line.  Beware of
 this when you search for the Subscription consent" email.
 
 **NOTE**: The "Subscription consent" email is usually sent by the FreeLists
 List Manager within a minute after clicking the **((Next >>))** button.
 If you don't see the "Subscription consent" email, check your spam folder.
 
-**NOTE**: If are having trouble receiving the "Subscription consent"
-email, [Contact the IOCCC](../contact.html), and you have tried
-several times, ask the [IOCCC judges](../judges.html) for assistance.
+**NOTE**: If are having trouble receiving the "Subscription consent" email, and
+you have tried a few times, [Contact the IOCCC](../contact.html) to ask the
+[IOCCC judges](../judges.html) for assistance.
 
 This email will contain a URL of the form:
 `https://www.freelists.org/v/ioccc28-reg/SOME-RANDOM-STUFF`.
 
-Click on that link.
+Click on that link. The email might look the below:
 
-**NOTE**: If you prefer to **NOT** click links in email, simply copy that
-URL from your "Subscription consent email" and paste it into your browser.
 
 <img src="../png/register.2_590x253-verify-email.png"
  alt="Subscription consent email"
  width=590 height=253>
+
+**NOTE**: If you prefer to **NOT** click links in email, simply copy that
+URL from your "Subscription consent email" and paste it into your browser. The
 
 
 <div id="step_d">
@@ -83,22 +82,23 @@ In your browser, for the link referenced in [Step C](#step_c), click the **((Nex
 
 
 <div id="step_e">
-## Step E: Content and Verify
+## Step E: Verify you have read the mailing list polices and that you consent to receiving emails
 </div>
 
-The FreeLists service that you verify that you:
+The FreeLists service requires that you verify that you:
 
 - Have read, understand, and agree to their "_Terms of Service_"
 - Have read, understand, and agree to their "_Privacy Policy_"
 - Are the owner or authorized user of the email you registered
 
-Once you have done this by clicking the 3 checkboxes, the **((Next >>))** button.
+Once you have done this by clicking the 3 checkboxes, click the **((Next >>))**
+button:
 
 <img src="../png/register.4_657x446-subscribe.png"
  alt="complete subscription"
  width=657 height=446>
 
- After clicking **((Next >>))**, you will be notified you will receive some email:
+After clicking **((Next >>))**, you will be notified that you will receive an email:
 
 <img src="../png/register.5_487x154-done.png"
  alt="registration is complete"
@@ -124,17 +124,18 @@ Read the "Welcome" email.
 
 **NOTE**: The "Welcome" email is usually sent by the FreeLists
 List Manager within a minute after clicking the **((Next >>))** button.
-If you don't see the "Subscription consent" email, check your spam folder.
+If you don't see the "Welcome" email, check your spam folder.
 
-**NOTE**: If are having trouble receiving the "Welcome" email,
-[Contact the IOCCC](../contact.html), and if you have tried
-several times, ask the [IOCCC judges](../judges.html) for assistance.
+**NOTE**: If are having trouble receiving the "Welcome" email, and you have
+tried several times,
+[Contact the IOCCC](../contact.html) to ask the [IOCCC judges](../judges.html)
+for assistance.
 
 <div id="step_i">
 ## Step I: Proceed with step 3
 </div>
 
-When the is [open](../status.html#open), proceed with
+When the contest is [open](../status.html#open), proceed with
 [Step 3: Wait for your submit server username and initial password](../faq.html#step_3).
 
 
@@ -156,8 +157,8 @@ or [open](../status.html#open).
 ### When the IOCCC status is _pending_
 
 While the contest is **[PENDING](../status.html#pending)**,
-you may **register for contest*, however you will **NOT**
-receive your own email message containing your [IOCCC submit server](https:/submit.ioccc.org)
+you may **register for contest**, however you will **NOT**
+receive an email message containing your [IOCCC submit server](https://submit.ioccc.org)
 **Username and Initial Password until the IOCCC is [open](../status.html#open)**.
 
 
@@ -165,19 +166,20 @@ receive your own email message containing your [IOCCC submit server](https:/subm
 
 While the contest is **[OPEN](../status.html#open)**,
 you may **register for the contest**.  Once you are registered **AND**
-the contest is [open](../status.html#open), you will receive your own email message containing your very own
+the contest is [open](../status.html#open), you will receive an email message containing your very own
 **Username and Initial Password until the contest is [open](../status.html#open)**.  You will need these
-to be able to [upload your submission](submit.html) to the [IOCCC submit server](https:/submit.ioccc.org).
+to be able to [upload your submissions](submit.html) to the [IOCCC submit
+server](https://submit.ioccc.org).
 
 See also the
-FAQ on "[how to upload your submission](submit.html)"
+FAQ on "[how to upload your submission](../faq.html#submit)"
 for more information on the submission process when the IOCCC [reopens](../status.html#open).
 
 
 ### When the IOCCC status is _judging_
 
 While the contest is **[PENDING](../status.html#pending)**,
-you **CANNOT REGISTER** as the current because the
+you **CANNOT REGISTER** because the
 [IOCCC judges](../judges.html) are in the process of judging the [submissions](../faq.html#how_many)
 they received while the contest was [open](../status.html#open).
 

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -1456,7 +1456,7 @@ generated <code>fibonacci.c</code> actually works; before it just printed <code>
 again (since it did not work anyway a segfault prevention was added here). He
 also fixed some array addressing (some of which might not be strictly necessary
 but as he was testing the <code>fibonacci.c</code> bug he ended up changing it anyway).</p>
-<p>BTW: why can’t the fix:</p>
+<p><strong>BTW</strong>: why can’t the fix:</p>
 <pre><code>    if (a[1]==NULL||a[2]==NULL||a[3]==NULL||a[4]==NULL||a[5]==NULL) return 1;</code></pre>
 <p>be changed to just test the value of <code>A</code> when <code>a</code> is argv and <code>A</code> is argc? You
 tell us!</p>
@@ -2457,7 +2457,7 @@ possible to get this to compile.</p>
 <p>Cody also added the rather useful <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/1996/gandalf/try.sh">try.sh</a> script to
 really demonstrate the different ways of running the program ends up showing
 either different output or the same output that we briefly pointed out.</p>
-<p>BTW: it is perilous to try the patience of
+<p><strong>BTW</strong>: it is perilous to try the patience of
 <a href="https://www.glyphweb.com/arda/g/gandalf.html">Gandalf</a>. Go ahead, try it! :-)</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="1996_huffman">

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -1484,7 +1484,7 @@ again (since it did not work anyway a segfault prevention was added here). He
 also fixed some array addressing (some of which might not be strictly necessary
 but as he was testing the `fibonacci.c` bug he ended up changing it anyway).
 
-BTW: why can't the fix:
+**BTW**: why can't the fix:
 
 ``` <!---c-->
     if (a[1]==NULL||a[2]==NULL||a[3]==NULL||a[4]==NULL||a[5]==NULL) return 1;
@@ -2987,7 +2987,7 @@ Cody also added the rather useful [try.sh](%%REPO_URL%%/1996/gandalf/try.sh) scr
 really demonstrate the different ways of running the program ends up showing
 either different output or the same output that we briefly pointed out.
 
-BTW: it is perilous to try the patience of
+**BTW**: it is perilous to try the patience of
 [Gandalf](https://www.glyphweb.com/arda/g/gandalf.html). Go ahead, try it! :-)
 
 


### PR DESCRIPTION
Make lines beginning (in markdown files) 'BTW' bold. Rebuilt the respective html pages.

Slight update to abstract in two entries (1985/shapiro and 1994/shapiro). One is changing 'defines' to '#defines' and the other was a typo fix.

Fixed make gen_next: added missing new files.

Various fixes in next/register.html (typos and other things).