### PR TITLE
Various fixes in next and top level directory

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -698,13 +698,13 @@ for doing so in your <code>remarks.md</code> file.</p>
 </div>
 </div>
 <p>The screenshots about <a href="next/submit.html">how to upload your submission to the IOCCC</a>
-may be helpful a helpful guide when using the <a href="https://submit.ioccc.org">IOCCC submit server</a>.</p>
+might be a helpful guide when using the <a href="https://submit.ioccc.org">IOCCC submit server</a>.</p>
 <p><strong>NOTE</strong>: You may modify a previous uploaded submission, if the contest is
-<a href="status.html#open">open</a>, by replacing the file in a slot. Please use
+<a href="status.html#open">open</a>, by replacing the file in a slot. Please use the
 <a href="#mkiocccentry">mkiocccentry tool</a> to rebuild the compressed tarball as
-this will update the timestamps and the filename generated: making it
-clear to the <a href="judges.html">IOCCC judges</a> that you intend to replace
-the older upload.</p>
+this will update the timestamps and the filename generated, as well as packaging
+any changes: making it clear to the <a href="judges.html">IOCCC judges</a> that you intend
+to replace the older upload.</p>
 <p><strong>IMPORTANT NOTE</strong>: The <a href="https://submit.ioccc.org">IOCCC submit server</a>
 is only ready for submissions
 <strong>ONLY WHEN THE CONTEST IS <a href="status.html#open">open</a></strong>.</p>
@@ -712,6 +712,9 @@ is only ready for submissions
 <strong>IMPORTANT NOTE</strong>: When the contest is <a href="status.html#closed">closed</a>, the
 <a href="https://submit.ioccc.org">IOCCC submit server</a>
 may be offline and unreachable as a web site.</p>
+<p><strong>NOTE</strong>: if you do need to update a submission, you might find the
+FAQ on “<a href="#answers_file">how to not have to re-enter information more than once</a>”
+useful.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="what_mkiocccentry">
 <div id="mkiocccentry">

--- a/faq.md
+++ b/faq.md
@@ -333,14 +333,14 @@ See also [Rule 17](next/rules.html#rule17)!
 </div>
 
 The screenshots about [how to upload your submission to the IOCCC](next/submit.html)
-may be helpful a helpful guide when using the [IOCCC submit server](https://submit.ioccc.org).
+might be a helpful guide when using the [IOCCC submit server](https://submit.ioccc.org).
 
 **NOTE**: You may modify a previous uploaded submission, if the contest is
-[open](status.html#open), by replacing the file in a slot.  Please use
+[open](status.html#open), by replacing the file in a slot.  Please use the
 [mkiocccentry tool](#mkiocccentry) to rebuild the compressed tarball as
-this will update the timestamps and the filename generated: making it
-clear to the [IOCCC judges](judges.html) that you intend to replace
-the older upload.
+this will update the timestamps and the filename generated, as well as packaging
+any changes: making it clear to the [IOCCC judges](judges.html) that you intend
+to replace the older upload.
 
 **IMPORTANT NOTE**: The [IOCCC submit server](https://submit.ioccc.org)
 is only ready for submissions
@@ -350,6 +350,11 @@ See [current status of the IOCCC](status.html) for details on the contest status
 **IMPORTANT NOTE**: When the contest is [closed](status.html#closed), the
 [IOCCC submit server](https://submit.ioccc.org)
 may be offline and unreachable as a web site.
+
+**NOTE**: if you do need to update a submission, you might find the
+FAQ on "[how to not have to re-enter information more than once](#answers_file)"
+useful.
+
 
 
 Jump to: [top](#)

--- a/next/README.md
+++ b/next/README.md
@@ -101,7 +101,7 @@ for more information on the submission process when the IOCCC [reopens](../statu
 
 ### When the IOCCC status is _judging_
 
-While the IOCCC status is **[JUDGING](../status.html#pending]**,
+While the IOCCC status is **[JUDGING](../status.html#judging)**,
 the [rules](rules.html) and [guidelines](guidelines.html) are
 for the when the was previously **[OPEN](../status.html#open)** for new submissions.
 

--- a/next/index.html
+++ b/next/index.html
@@ -498,7 +498,7 @@ as changes to them may have been made while the contest was “<strong><a href="
 FAQ on “<a href="submit.html">how to submit</a>”
 for more information on the submission process when the IOCCC <a href="../status.html#open">reopens</a>.</p>
 <h3 id="when-the-ioccc-status-is-judging">When the IOCCC status is <em>judging</em></h3>
-<p>While the IOCCC status is <strong>[JUDGING](../status.html#pending]</strong>,
+<p>While the IOCCC status is <strong><a href="../status.html#judging">JUDGING</a></strong>,
 the <a href="rules.html">rules</a> and <a href="guidelines.html">guidelines</a> are
 for the when the was previously <strong><a href="../status.html#open">OPEN</a></strong> for new submissions.</p>
 <p>See the <a href="../news.html">IOCCC news</a> as well as the <a href="https://fosstodon.org/@ioccc">IOCCC

--- a/next/pw-change.html
+++ b/next/pw-change.html
@@ -426,7 +426,7 @@
 <!-- BEFORE: 1st line of markdown file: next/pw-change.md -->
 <h1 id="change-your-submit-server-initial-password">Change your submit server initial password</h1>
 <p>Using the <strong>Username</strong> and <strong>Initial password</strong> you receive via
-email in <a href="#step_3">step 3</a>, you need to login to the <a href="https:/submit.ioccc.org">IOCCC submit
+email in <a href="../faq.html#step_3">step 3</a>, you need to login to the <a href="https://submit.ioccc.org">IOCCC submit
 server</a>.</p>
 <p><strong>IMPORTANT NOTE</strong>: You must change your password <strong>WITHIN 72 HOURS</strong>
 from when one of the <a href="../judges.html">IOCCC judges</a> sent that email.</p>
@@ -441,7 +441,7 @@ in your browser. It should look like this:</p>
 <p><img src="../png/submit-server-login.png"
  alt="submit server login screen"
  width=710 height=562></p>
-<p>The login is the UUID you were provided when you registered for the IOCCC and
+<p>The username is the UUID you were provided when you registered for the IOCCC and
 the password is the initial password you were provided with. Click “Login”.</p>
 <p>If this is the first time you have logged in with this UUID, you will
 be required to change your password.</p>
@@ -456,8 +456,12 @@ username), your old (initial) password and a new password. For instance:</p>
  width=710 height=808></p>
 <p>Click “Change Password”.</p>
 <p>Once this is done, you will be able to log in again with your UUID
-username and new password.</p>
-<p>When the is <a href="../status.html#open">open</a>, proceed with
+username and new password. This is what it will look like when you change your
+password:</p>
+<p><img src="../png/submit-server-passwd-changed.png"
+ alt="submit server password changed"
+ width=710 height=344></p>
+<p>When the contest is <a href="../status.html#open">open</a>, proceed with
 <a href="../faq.html#step_5">Step 5: Obtain and compile the latest mkiocccentry toolkit</a>.</p>
 <!--
 

--- a/next/pw-change.md
+++ b/next/pw-change.md
@@ -1,8 +1,8 @@
 # Change your submit server initial password
 
 Using the **Username** and **Initial password** you receive via
-email in [step 3](#step_3), you need to login to the [IOCCC submit
-server](https:/submit.ioccc.org).
+email in [step 3](../faq.html#step_3), you need to login to the [IOCCC submit
+server](https://submit.ioccc.org).
 
 **IMPORTANT NOTE**: You must change your password **WITHIN 72 HOURS**
 from when one of the [IOCCC judges](../judges.html) sent that email.
@@ -22,7 +22,7 @@ in your browser.  It should look like this:
  alt="submit server login screen"
  width=710 height=562>
 
-The login is the UUID you were provided when you registered for the IOCCC and
+The username is the UUID you were provided when you registered for the IOCCC and
 the password is the initial password you were provided with. Click "Login".
 
 If this is the first time you have logged in with this UUID, you will
@@ -44,9 +44,14 @@ username), your old (initial) password and a new password. For instance:
 Click "Change Password".
 
 Once this is done, you will be able to log in again with your UUID
-username and new password.
+username and new password. This is what it will look like when you change your
+password:
 
-When the is [open](../status.html#open), proceed with
+<img src="../png/submit-server-passwd-changed.png"
+ alt="submit server password changed"
+ width=710 height=344>
+
+When the contest is [open](../status.html#open), proceed with
 [Step 5: Obtain and compile the latest mkiocccentry toolkit](../faq.html#step_5).
 
 

--- a/next/submit.html
+++ b/next/submit.html
@@ -431,13 +431,16 @@ is only ready for submissions
 <p>See <a href="../status.html">current status of the IOCCC</a> for details on the contest status.
 <strong>IMPORTANT NOTE</strong>: When the contest is <a href="../status.html#closed">closed</a>, the
 <a href="https://submit.ioccc.org">IOCCC submit server</a>
-may be offline and unreachable as a web site.</p>
+might be offline and unreachable as a website.</p>
 <p>To login, open <a href="https://submit.ioccc.org">https://submit.ioccc.org</a>
-in your browser. It should look like this:</p>
-<p><img src="../png/submit-server-passwd-changed.png"
- alt="submit server password changed"
+in your browser. Fill in your login credentials and click “Login”.
+It might look something like:</p>
+<p><img src="../png/submit-server-login.png"
+ alt="submit server login page"
  width=710 height=344></p>
-<p>.. click “Login”.</p>
+<p>If you’ve not logged in before, you’ll have to change your password first. See
+the file <a href="pw-change.html">pw-change.html</a> for more details. After that you will
+have to log back in.</p>
 <p>Once you’ve logged in, you will see submit slots. Each slot is for one
 submission so if you update a submission, make sure you choose the right one so
 you do not overwrite the wrong one!</p>

--- a/next/submit.md
+++ b/next/submit.md
@@ -7,16 +7,20 @@ is only ready for submissions
 See [current status of the IOCCC](../status.html) for details on the contest status.
 **IMPORTANT NOTE**: When the contest is [closed](../status.html#closed), the
 [IOCCC submit server](https://submit.ioccc.org)
-may be offline and unreachable as a web site.
+might be offline and unreachable as a website.
 
 To login, open [https://submit.ioccc.org](https://submit.ioccc.org)
-in your browser.  It should look like this:
+in your browser. Fill in your login credentials and click "Login".
+It might look something like:
 
-<img src="../png/submit-server-passwd-changed.png"
- alt="submit server password changed"
+<img src="../png/submit-server-login.png"
+ alt="submit server login page"
  width=710 height=344>
 
-.. click "Login".
+
+If you've not logged in before, you'll have to change your password first. See
+the file [pw-change.html](pw-change.html) for more details. After that you will
+have to log back in.
 
 Once you've logged in, you will see submit slots. Each slot is for one
 submission so if you update a submission, make sure you choose the right one so

--- a/status.html
+++ b/status.html
@@ -468,7 +468,8 @@ been released.</p>
 <p>You may <a href="next/register.html">register for the IOCCC</a> while the contest is <a href="#pending">pending</a>,
 however you will <strong>NOT</strong> receive your own Email message containing your very own
 <strong>Username and Initial Password until the contest is <a href="#open">open</a></strong>. You will need these
-to be able to <a href="next/submit.html">upload your submission</a> to the <a href="https:/submit.ioccc.org">IOCCC submit server</a>.</p>
+to be able to <a href="next/submit.html">upload your submission</a> to the <a href="https://submit.ioccc.org">IOCCC submit
+server</a>.</p>
 <p>Once contest moves from <a href="#pending%22">pending</a> to <a href="#open">open</a>, an announcement
 Email will be sent out to the mailing list of those have successfully registered for the IOCCC.
 In addition, an announcement will be made to the <a href="news.html">IOCCC news</a> in case you miss
@@ -492,7 +493,7 @@ may <a href="next/submit.html">upload their submissions</a> to the <a href="http
 FAQ on “<a href="faq.html#submit">how to submit</a>”
 for more information.</p>
 <p>See the <a href="news.html">IOCCC news</a> page for details on any IOCCC related deadlines
-such as when the contest will <a href="#close">close</a>.</p>
+such as when the contest will <a href="#closed">close</a>.</p>
 <p>The <a href="next/rules.html">IOCCC rules</a>, <a href="next/guidelines.html">IOCCC guidelines</a>,
 and <a href="https://github.com/ioccc-src/mkiocccentry">IOCCC mkiocccentry tools</a>
 are now official. Should you have any questions about these, please see the
@@ -505,7 +506,7 @@ as changes to them may have been made while the contest was “<strong><a href="
 FAQ on “<a href="faq.html#submit">how to submit</a>”
 for more information on the submission process when the IOCCC <a href="#open">reopens</a>.</p>
 <h4 id="judging">“<strong>judging</strong>”</h4>
-<p>While contest is <strong>[JUDGING][#jugding]</strong>, you cannot <a href="next/register.html">register</a>
+<p>While contest is <strong><a href="#judging">JUDGING</a></strong>, you cannot <a href="next/register.html">register</a>
 nor can you <a href="next/submit.html">upload submissions</a>. This is because the
 <a href="judges.html">IOCCC judges</a> are in the process of judging the <a href="faq.html#how_many">submissions</a>
 they received while the contest was <a href="#open">open</a>.</p>
@@ -527,7 +528,7 @@ winning entries page</a>.</p></li>
 <li><p>Update the <a href="news.html">IOCCC news</a> page.</p></li>
 </ul>
 <h4 id="closed">“<strong>closed</strong>”</h4>
-<p>While contest is <strong>[CLOSED][#closed]</strong>, you cannot <a href="next/register.html">register</a>
+<p>While contest is <strong><a href="#closed">CLOSED</a></strong>, you cannot <a href="next/register.html">register</a>
 nor can you <a href="next/submit.html">upload submissions</a>. You have to wait for the
 next contest to <a href="#open">open</a>.</p>
 <p>See the <a href="years.html">IOCCC winning entries page</a> for the entries that have won

--- a/status.md
+++ b/status.md
@@ -51,7 +51,8 @@ been released.
 You may [register for the IOCCC](next/register.html) while the contest is [pending](#pending),
 however you will **NOT** receive your own Email message containing your very own
 **Username and Initial Password until the contest is [open](#open)**.  You will need these
-to be able to [upload your submission](next/submit.html) to the [IOCCC submit server](https:/submit.ioccc.org).
+to be able to [upload your submission](next/submit.html) to the [IOCCC submit
+server](https://submit.ioccc.org).
 
 Once contest moves from [pending](#pending") to [open](#open), an announcement
 Email will be sent out to the mailing list of those have successfully registered for the IOCCC.
@@ -86,7 +87,7 @@ FAQ on "[how to submit](faq.html#submit)"
 for more information.
 
 See the [IOCCC news](news.html) page for details on any IOCCC related deadlines
-such as when the contest will [close](#close).
+such as when the contest will [close](#closed).
 
 The [IOCCC rules](next/rules.html), [IOCCC guidelines](next/guidelines.html),
 and [IOCCC mkiocccentry tools](https://github.com/ioccc-src/mkiocccentry)
@@ -107,7 +108,7 @@ for more information on the submission process when the IOCCC [reopens](#open).
 #### "**judging**"
 </div>
 
-While contest is **[JUDGING][#jugding]**, you cannot [register](next/register.html)
+While contest is **[JUDGING](#judging)**, you cannot [register](next/register.html)
 nor can you [upload submissions](next/submit.html).  This is because the
 [IOCCC judges](judges.html) are in the process of judging the [submissions](faq.html#how_many)
 they received while the contest was [open](#open).
@@ -138,7 +139,7 @@ winning entries page](years.html).
 
 #### "**closed**"
 
-While contest is **[CLOSED][#closed]**, you cannot [register](next/register.html)
+While contest is **[CLOSED](#closed)**, you cannot [register](next/register.html)
 nor can you [upload submissions](next/submit.html).  You have to wait for the
 next contest to [open](#open).
 


### PR DESCRIPTION
Some broken links were fixed in some of the files like next/index.html, next/pw-change.html, next/index.html and status.html.

Some wrong images were used in next/submit.html (or at least referred to wrong if not wrong image).

Useful update to FAQ about the answers file in mkiocccentry.

There might have been other things.

This might be all that is needed for next/ wrt the register/change password/submit but it's possible something has slipped through.