### PR TITLE
Fix menu and various other fixes

### DIFF
--- a/1984/anonymous/index.html
+++ b/1984/anonymous/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1984/decot/index.html
+++ b/1984/decot/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1984/index.html
+++ b/1984/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1984/laman/index.html
+++ b/1984/laman/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1984/mullender/index.html
+++ b/1984/mullender/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1985/applin/index.html
+++ b/1985/applin/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1985/august/index.html
+++ b/1985/august/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1985/index.html
+++ b/1985/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1985/lycklama/index.html
+++ b/1985/lycklama/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1985/shapiro/index.html
+++ b/1985/shapiro/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1985/sicherman/index.html
+++ b/1985/sicherman/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/applin/index.html
+++ b/1986/applin/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/august/index.html
+++ b/1986/august/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/bright/index.html
+++ b/1986/bright/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/hague/index.html
+++ b/1986/hague/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/holloway/index.html
+++ b/1986/holloway/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/index.html
+++ b/1986/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1986/marshall/compilers.html
+++ b/1986/marshall/compilers.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/marshall/index.html
+++ b/1986/marshall/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/pawka/index.html
+++ b/1986/pawka/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/stein/index.html
+++ b/1986/stein/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1986/wall/index.html
+++ b/1986/wall/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1987/biggar/index.html
+++ b/1987/biggar/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1987/heckbert/index.html
+++ b/1987/heckbert/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1987/hines/index.html
+++ b/1987/hines/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1987/index.html
+++ b/1987/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1987/korn/index.html
+++ b/1987/korn/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1987/lievaart/index.html
+++ b/1987/lievaart/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1987/wall/index.html
+++ b/1987/wall/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1987/westley/index.html
+++ b/1987/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/applin/index.html
+++ b/1988/applin/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/dale/index.html
+++ b/1988/dale/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/index.html
+++ b/1988/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1988/isaak/index.html
+++ b/1988/isaak/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/litmaath/index.html
+++ b/1988/litmaath/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/phillipps/index.html
+++ b/1988/phillipps/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/reddy/index.html
+++ b/1988/reddy/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/robison/index.html
+++ b/1988/robison/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/spinellis/index.html
+++ b/1988/spinellis/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1988/westley/index.html
+++ b/1988/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/fubar/index.html
+++ b/1989/fubar/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/index.html
+++ b/1989/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1989/jar.1/index.html
+++ b/1989/jar.1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/jar.2/index.html
+++ b/1989/jar.2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/ovdluhe/index.html
+++ b/1989/ovdluhe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/paul/index.html
+++ b/1989/paul/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/robison/index.html
+++ b/1989/robison/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/roemer/index.html
+++ b/1989/roemer/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/tromp/index.html
+++ b/1989/tromp/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/vanb/index.html
+++ b/1989/vanb/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1989/westley/index.html
+++ b/1989/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/baruch/index.html
+++ b/1990/baruch/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/cmills/index.html
+++ b/1990/cmills/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/dds/index.html
+++ b/1990/dds/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/dg/index.html
+++ b/1990/dg/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/index.html
+++ b/1990/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1990/jaw/index.html
+++ b/1990/jaw/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/pjr/index.html
+++ b/1990/pjr/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/scjones/index.html
+++ b/1990/scjones/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/stig/index.html
+++ b/1990/stig/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/tbr/index.html
+++ b/1990/tbr/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/theorem/index.html
+++ b/1990/theorem/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1990/westley/index.html
+++ b/1990/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/ant/index.html
+++ b/1991/ant/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/brnstnd/index.html
+++ b/1991/brnstnd/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/brnstnd/sorta.README.html
+++ b/1991/brnstnd/sorta.README.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/buzzard/index.html
+++ b/1991/buzzard/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/cdupont/index.html
+++ b/1991/cdupont/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/davidguy/index.html
+++ b/1991/davidguy/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/dds/index.html
+++ b/1991/dds/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/fine/index.html
+++ b/1991/fine/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/index.html
+++ b/1991/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1991/rince/index.html
+++ b/1991/rince/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1991/westley/index.html
+++ b/1991/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/adrian/index.html
+++ b/1992/adrian/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/albert/index.html
+++ b/1992/albert/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/ant/index.html
+++ b/1992/ant/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/buzzard.1/index.html
+++ b/1992/buzzard.1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/buzzard.2/buzzard.2.README.html
+++ b/1992/buzzard.2/buzzard.2.README.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/buzzard.2/buzzard.2.design.html
+++ b/1992/buzzard.2/buzzard.2.design.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/buzzard.2/index.html
+++ b/1992/buzzard.2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/gson/index.html
+++ b/1992/gson/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/imc/index.html
+++ b/1992/imc/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/index.html
+++ b/1992/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1992/kivinen/index.html
+++ b/1992/kivinen/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/lush/index.html
+++ b/1992/lush/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/marangon/index.html
+++ b/1992/marangon/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/nathan/index.html
+++ b/1992/nathan/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/vern/index.html
+++ b/1992/vern/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1992/westley/index.html
+++ b/1992/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/ant/index.html
+++ b/1993/ant/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/cmills/index.html
+++ b/1993/cmills/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/dgibson/index.html
+++ b/1993/dgibson/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/ejb/hanoi.html
+++ b/1993/ejb/hanoi.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/ejb/index.html
+++ b/1993/ejb/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/ejb/patience.html
+++ b/1993/ejb/patience.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/index.html
+++ b/1993/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1993/jonth/index.html
+++ b/1993/jonth/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/leo/index.html
+++ b/1993/leo/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/lmfjyh/index.html
+++ b/1993/lmfjyh/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/plummer/index.html
+++ b/1993/plummer/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/rince/design.html
+++ b/1993/rince/design.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/rince/index.html
+++ b/1993/rince/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/schnitzi/index.html
+++ b/1993/schnitzi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1993/vanb/index.html
+++ b/1993/vanb/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/dodsond1/index.html
+++ b/1994/dodsond1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/dodsond2/index.html
+++ b/1994/dodsond2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/horton/index.html
+++ b/1994/horton/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/imc/index.html
+++ b/1994/imc/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/index.html
+++ b/1994/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1994/ldb/index.html
+++ b/1994/ldb/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/schnitzi/index.html
+++ b/1994/schnitzi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/shapiro/index.html
+++ b/1994/shapiro/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/shapiro/shapiro.html
+++ b/1994/shapiro/shapiro.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/smr/index.html
+++ b/1994/smr/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/tvr/index.html
+++ b/1994/tvr/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/weisberg/index.html
+++ b/1994/weisberg/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1994/westley/index.html
+++ b/1994/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/cdua/index.html
+++ b/1995/cdua/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/dodsond1/index.html
+++ b/1995/dodsond1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/dodsond2/index.html
+++ b/1995/dodsond2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/esde/index.html
+++ b/1995/esde/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/garry/index.html
+++ b/1995/garry/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/heathbar/index.html
+++ b/1995/heathbar/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/index.html
+++ b/1995/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1995/leo/index.html
+++ b/1995/leo/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/leo/secret.html
+++ b/1995/leo/secret.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/makarios/index.html
+++ b/1995/makarios/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/savastio/index.html
+++ b/1995/savastio/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/schnitzi/index.html
+++ b/1995/schnitzi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/spinellis/index.html
+++ b/1995/spinellis/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1995/vanschnitz/index.html
+++ b/1995/vanschnitz/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/august/index.html
+++ b/1996/august/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/dalbec/index.html
+++ b/1996/dalbec/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/eldby/index.html
+++ b/1996/eldby/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/gandalf/index.html
+++ b/1996/gandalf/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/huffman/index.html
+++ b/1996/huffman/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/index.html
+++ b/1996/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1996/jonth/index.html
+++ b/1996/jonth/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/rcm/index.html
+++ b/1996/rcm/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/schweikh1/index.html
+++ b/1996/schweikh1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/schweikh2/index.html
+++ b/1996/schweikh2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/schweikh3/index.html
+++ b/1996/schweikh3/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1996/westley/index.html
+++ b/1996/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/banks/index.html
+++ b/1998/banks/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/bas1/index.html
+++ b/1998/bas1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/bas2/index.html
+++ b/1998/bas2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/chaos/index.html
+++ b/1998/chaos/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/df/index.html
+++ b/1998/df/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/dlowe/index.html
+++ b/1998/dlowe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/dloweneil/index.html
+++ b/1998/dloweneil/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/dorssel/dorssel.html
+++ b/1998/dorssel/dorssel.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/dorssel/index.html
+++ b/1998/dorssel/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/fanf/index.html
+++ b/1998/fanf/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/index.html
+++ b/1998/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/1998/schnitzi/index.html
+++ b/1998/schnitzi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/schweikh1/index.html
+++ b/1998/schweikh1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/schweikh1/macos.html
+++ b/1998/schweikh1/macos.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/schweikh2/index.html
+++ b/1998/schweikh2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/schweikh3/index.html
+++ b/1998/schweikh3/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/1998/tomtorfs/index.html
+++ b/1998/tomtorfs/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/anderson/index.html
+++ b/2000/anderson/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/bellard/index.html
+++ b/2000/bellard/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/bmeyer/index.html
+++ b/2000/bmeyer/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/briddlebane/index.html
+++ b/2000/briddlebane/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/dhyang/index.html
+++ b/2000/dhyang/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/dlowe/index.html
+++ b/2000/dlowe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/index.html
+++ b/2000/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2000/jarijyrki/index.html
+++ b/2000/jarijyrki/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/natori/index.html
+++ b/2000/natori/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/primenum/index.html
+++ b/2000/primenum/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/rince/index.html
+++ b/2000/rince/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/robison/index.html
+++ b/2000/robison/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/schneiderwent/index.html
+++ b/2000/schneiderwent/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/thadgavin/index.html
+++ b/2000/thadgavin/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2000/tomx/index.html
+++ b/2000/tomx/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/anonymous/index.html
+++ b/2001/anonymous/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/bellard/index.html
+++ b/2001/bellard/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/cheong/index.html
+++ b/2001/cheong/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/coupard/index.html
+++ b/2001/coupard/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/ctk/index.html
+++ b/2001/ctk/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/dgbeards/index.html
+++ b/2001/dgbeards/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/herrmann1/index.html
+++ b/2001/herrmann1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/herrmann2/index.html
+++ b/2001/herrmann2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/index.html
+++ b/2001/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2001/jason/index.html
+++ b/2001/jason/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/kev/index.html
+++ b/2001/kev/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/ollinger/index.html
+++ b/2001/ollinger/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/rosten/index.html
+++ b/2001/rosten/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/schweikh/index.html
+++ b/2001/schweikh/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/westley/index.html
+++ b/2001/westley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2001/williams/index.html
+++ b/2001/williams/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/anonymous/index.html
+++ b/2004/anonymous/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/arachnid/index.html
+++ b/2004/arachnid/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/burley/index.html
+++ b/2004/burley/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/gavare/index.html
+++ b/2004/gavare/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/gavin/gavin.html
+++ b/2004/gavin/gavin.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/gavin/index.html
+++ b/2004/gavin/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/hibachi/index.html
+++ b/2004/hibachi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/hoyle/index.html
+++ b/2004/hoyle/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/index.html
+++ b/2004/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2004/jdalbec/index.html
+++ b/2004/jdalbec/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/kopczynski/index.html
+++ b/2004/kopczynski/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/newbern/index.html
+++ b/2004/newbern/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/omoikane/index.html
+++ b/2004/omoikane/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/schnitzi/index.html
+++ b/2004/schnitzi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/sds/index.html
+++ b/2004/sds/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/vik1/index.html
+++ b/2004/vik1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2004/vik2/index.html
+++ b/2004/vik2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/aidan/index.html
+++ b/2005/aidan/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/anon/index.html
+++ b/2005/anon/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/boutines/index.html
+++ b/2005/boutines/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/chia/index.html
+++ b/2005/chia/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/giljade/index.html
+++ b/2005/giljade/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/index.html
+++ b/2005/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2005/jetro/index.html
+++ b/2005/jetro/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/klausler/index.html
+++ b/2005/klausler/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/mikeash/index.html
+++ b/2005/mikeash/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/mynx/index.html
+++ b/2005/mynx/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/persano/index.html
+++ b/2005/persano/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/sykes/index.html
+++ b/2005/sykes/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/timwi/index.html
+++ b/2005/timwi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/toledo/index.html
+++ b/2005/toledo/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/vik/index.html
+++ b/2005/vik/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2005/vince/index.html
+++ b/2005/vince/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/birken/index.html
+++ b/2006/birken/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/borsanyi/index.html
+++ b/2006/borsanyi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/grothe/index.html
+++ b/2006/grothe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/hamre/index.html
+++ b/2006/hamre/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/index.html
+++ b/2006/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2006/meyer/index.html
+++ b/2006/meyer/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/monge/index.html
+++ b/2006/monge/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/night/index.html
+++ b/2006/night/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/sloane/index.html
+++ b/2006/sloane/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/stewart/index.html
+++ b/2006/stewart/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/sykes1/index.html
+++ b/2006/sykes1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/sykes2/index.html
+++ b/2006/sykes2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/toledo1/index.html
+++ b/2006/toledo1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/toledo2/index.html
+++ b/2006/toledo2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2006/toledo3/index.html
+++ b/2006/toledo3/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/akari/index.html
+++ b/2011/akari/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/blakely/index.html
+++ b/2011/blakely/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/borsanyi/index.html
+++ b/2011/borsanyi/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/dlowe/index.html
+++ b/2011/dlowe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/eastman/index.html
+++ b/2011/eastman/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/fredriksson/index.html
+++ b/2011/fredriksson/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/goren/index.html
+++ b/2011/goren/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/hamaji/index.html
+++ b/2011/hamaji/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/hou/index.html
+++ b/2011/hou/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/index.html
+++ b/2011/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2011/konno/index.html
+++ b/2011/konno/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/richards/index.html
+++ b/2011/richards/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/toledo/index.html
+++ b/2011/toledo/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/vik/index.html
+++ b/2011/vik/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2011/zucker/index.html
+++ b/2011/zucker/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/blakely/index.html
+++ b/2012/blakely/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/deckmyn/deckmyn.html
+++ b/2012/deckmyn/deckmyn.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/deckmyn/index.html
+++ b/2012/deckmyn/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/dlowe/index.html
+++ b/2012/dlowe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/endoh1/index.html
+++ b/2012/endoh1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/endoh2/index.html
+++ b/2012/endoh2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/grothe/index.html
+++ b/2012/grothe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/hamano/index.html
+++ b/2012/hamano/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/hou/hint.html
+++ b/2012/hou/hint.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/hou/index.html
+++ b/2012/hou/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/index.html
+++ b/2012/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2012/kang/index.html
+++ b/2012/kang/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/konno/index.html
+++ b/2012/konno/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/omoikane/index.html
+++ b/2012/omoikane/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/tromp/how.html
+++ b/2012/tromp/how.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/tromp/index.html
+++ b/2012/tromp/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/vik/index.html
+++ b/2012/vik/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2012/zeitak/index.html
+++ b/2012/zeitak/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/birken/index.html
+++ b/2013/birken/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/cable1/index.html
+++ b/2013/cable1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/cable2/index.html
+++ b/2013/cable2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/cable3/index.html
+++ b/2013/cable3/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/dlowe/index.html
+++ b/2013/dlowe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/endoh1/index.html
+++ b/2013/endoh1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/endoh2/index.html
+++ b/2013/endoh2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/endoh3/index.html
+++ b/2013/endoh3/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/endoh4/index.html
+++ b/2013/endoh4/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/hou/doc/example.html
+++ b/2013/hou/doc/example.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../../faq.html#compiling">

--- a/2013/hou/index.html
+++ b/2013/hou/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/index.html
+++ b/2013/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2013/mills/index.html
+++ b/2013/mills/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/misaka/index.html
+++ b/2013/misaka/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/morgan1/index.html
+++ b/2013/morgan1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/morgan2/index.html
+++ b/2013/morgan2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2013/robison/index.html
+++ b/2013/robison/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/birken/index.html
+++ b/2014/birken/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/deak/index.html
+++ b/2014/deak/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/endoh1/index.html
+++ b/2014/endoh1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/endoh1/quine-qr.html
+++ b/2014/endoh1/quine-qr.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/endoh2/index.html
+++ b/2014/endoh2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/index.html
+++ b/2014/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2014/maffiodo1/index.html
+++ b/2014/maffiodo1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/maffiodo2/index.html
+++ b/2014/maffiodo2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/morgan/index.html
+++ b/2014/morgan/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/sinon/index.html
+++ b/2014/sinon/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/skeggs/index.html
+++ b/2014/skeggs/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/vik/index.html
+++ b/2014/vik/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2014/wiedijk/index.html
+++ b/2014/wiedijk/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/burton/index.html
+++ b/2015/burton/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/burton/obfuscation.html
+++ b/2015/burton/obfuscation.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/burton/road.to.obscurity.html
+++ b/2015/burton/road.to.obscurity.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/dogon/index.html
+++ b/2015/dogon/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/duble/index.html
+++ b/2015/duble/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/endoh1/index.html
+++ b/2015/endoh1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/endoh2/index.html
+++ b/2015/endoh2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/endoh3/index.html
+++ b/2015/endoh3/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/endoh4/index.html
+++ b/2015/endoh4/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/hou/index.html
+++ b/2015/hou/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/howe/index.html
+++ b/2015/howe/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/index.html
+++ b/2015/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2015/mills1/index.html
+++ b/2015/mills1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/mills2/index.html
+++ b/2015/mills2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/muth/index.html
+++ b/2015/muth/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/schweikhardt/index.html
+++ b/2015/schweikhardt/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2015/yang/index.html
+++ b/2015/yang/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/algmyr/index.html
+++ b/2018/algmyr/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/anderson/index.html
+++ b/2018/anderson/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/bellard/index.html
+++ b/2018/bellard/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/burton1/index.html
+++ b/2018/burton1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/burton2/discrepancies.html
+++ b/2018/burton2/discrepancies.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/burton2/index.html
+++ b/2018/burton2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/ciura/index.html
+++ b/2018/ciura/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/endoh1/index.html
+++ b/2018/endoh1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/endoh2/index.html
+++ b/2018/endoh2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/ferguson/FILES.html
+++ b/2018/ferguson/FILES.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/ferguson/index.html
+++ b/2018/ferguson/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/ferguson/rpm.html
+++ b/2018/ferguson/rpm.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/giles/index.html
+++ b/2018/giles/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/hou/index.html
+++ b/2018/hou/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/index.html
+++ b/2018/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2018/mills/index.html
+++ b/2018/mills/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/poikola/index.html
+++ b/2018/poikola/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/vokes/index.html
+++ b/2018/vokes/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2018/yang/index.html
+++ b/2018/yang/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/adamovsky/index.html
+++ b/2019/adamovsky/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/burton/index.html
+++ b/2019/burton/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/ciura/index.html
+++ b/2019/ciura/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/diels-grabsch1/index.html
+++ b/2019/diels-grabsch1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/diels-grabsch2/index.html
+++ b/2019/diels-grabsch2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/dogon/index.html
+++ b/2019/dogon/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/duble/index.html
+++ b/2019/duble/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/endoh/index.html
+++ b/2019/endoh/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/giles/index.html
+++ b/2019/giles/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/index.html
+++ b/2019/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2019/karns/index.html
+++ b/2019/karns/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/lynn/index.html
+++ b/2019/lynn/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/mills/index.html
+++ b/2019/mills/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/poikola/index.html
+++ b/2019/poikola/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2019/yang/index.html
+++ b/2019/yang/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/burton/index.html
+++ b/2020/burton/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/carlini/index.html
+++ b/2020/carlini/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/endoh1/index.html
+++ b/2020/endoh1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/endoh2/index.html
+++ b/2020/endoh2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/endoh2/obfuscation/index.html
+++ b/2020/endoh2/obfuscation/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../../faq.html#compiling">

--- a/2020/endoh3/index.html
+++ b/2020/endoh3/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/COMPILING.html
+++ b/2020/ferguson1/COMPILING.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/HACKING.html
+++ b/2020/ferguson1/HACKING.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/bugs.html
+++ b/2020/ferguson1/bugs.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/cannibalism.log.html
+++ b/2020/ferguson1/cannibalism.log.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/chocolate-cake.html
+++ b/2020/ferguson1/chocolate-cake.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/crazy.log.html
+++ b/2020/ferguson1/crazy.log.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/gameplay.html
+++ b/2020/ferguson1/gameplay.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/index.html
+++ b/2020/ferguson1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/obfuscation.html
+++ b/2020/ferguson1/obfuscation.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/terminals.html
+++ b/2020/ferguson1/terminals.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson1/troubleshooting.html
+++ b/2020/ferguson1/troubleshooting.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson2/obfuscation.html
+++ b/2020/ferguson2/obfuscation.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson2/recode.html
+++ b/2020/ferguson2/recode.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/ferguson2/testing-procedure.html
+++ b/2020/ferguson2/testing-procedure.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/giles/index.html
+++ b/2020/giles/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/index.html
+++ b/2020/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/2020/kurdyukov1/index.html
+++ b/2020/kurdyukov1/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/kurdyukov2/index.html
+++ b/2020/kurdyukov2/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/kurdyukov3/index.html
+++ b/2020/kurdyukov3/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/kurdyukov4/index.html
+++ b/2020/kurdyukov4/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/otterness/index.html
+++ b/2020/otterness/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/tsoj/index.html
+++ b/2020/tsoj/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/2020/yang/index.html
+++ b/2020/yang/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/CODE_OF_CONDUCT.html
+++ b/CODE_OF_CONDUCT.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/README.html
+++ b/README.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/SECURITY.html
+++ b/SECURITY.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/about.html
+++ b/about.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/archive/historic/index.html
+++ b/archive/historic/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../../faq.html#compiling">

--- a/author/index.html
+++ b/author/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/authors.html
+++ b/authors.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/bin/index.html
+++ b/bin/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/bugs.html
+++ b/bugs.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/contact.html
+++ b/contact.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/faq.html
+++ b/faq.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">
@@ -708,10 +708,10 @@ to replace the older upload.</p>
 <p><strong>IMPORTANT NOTE</strong>: The <a href="https://submit.ioccc.org">IOCCC submit server</a>
 is only ready for submissions
 <strong>ONLY WHEN THE CONTEST IS <a href="status.html#open">open</a></strong>.</p>
-<p>See <a href="status.html">current status of the IOCCC</a> for details on the contest status.
-<strong>IMPORTANT NOTE</strong>: When the contest is <a href="status.html#closed">closed</a>, the
+<p>See <a href="status.html">current status of the IOCCC</a> for details on the contest status.</p>
+<p><strong>IMPORTANT NOTE</strong>: When the contest is <a href="status.html#closed">closed</a>, the
 <a href="https://submit.ioccc.org">IOCCC submit server</a>
-may be offline and unreachable as a web site.</p>
+might be offline and unreachable as a website.</p>
 <p><strong>NOTE</strong>: if you do need to update a submission, you might find the
 FAQ on “<a href="#answers_file">how to not have to re-enter information more than once</a>”
 useful.</p>
@@ -742,7 +742,7 @@ code, your Makefile, your remarks, any other data files you wish to provide (up
 to a maximum, including the mandatory files, defined in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>
 as <code>MAX_FILE_COUNT</code>) and other information about your submission,
-information about the author (or authors), and then runs a lot of tests before (if
+information about the author (or authors), and then it runs a lot of tests before (if
 all is OK) forming your tarball. After this is done it will additionally run the
 <code>txzchk(1)</code> tool (which runs the <code>fnamchk(1)</code> tool) on the submission tarball.
 The tool <code>chkentry(1)</code> will also be run, before creating the tarball. See the
@@ -823,7 +823,7 @@ be the <em>subdirectory</em> with your submission’s files</strong>.</p>
 <p>The <code>mkiocccentry(1)</code> tool will ask you for information about your
 submission <em>as well as author details</em> (that will only be looked at if the
 submission wins), run some tests and run a number of other tools, as briefly
-mentioned, and as described in the
+mentioned earlier, and as described in the
 “<a href="#mkiocccentry_details">finer details</a>” section.</p>
 <p>See also the
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md">mkiocccentry repo FAQ</a>
@@ -846,8 +846,7 @@ or <a href="https://unix.org/online.html">later SUS</a>.</p>
 <h3 id="q-0.3-what-should-i-put-in-my-submission-makefile">Q 0.3: What should I put in my submission Makefile?</h3>
 </div>
 </div>
-<p>We recommend starting with the <a href="next/Makefile.example">sample
-Makefile</a>
+<p>We recommend starting with the sample
 (renamed as <code>Makefile</code> of course) as a starting point for your
 entry’s <code>Makefile</code>:</p>
 <ul>
@@ -946,8 +945,8 @@ it, not very obfuscated entries have a minuscule chance to win (although
 <a href="2000/tomx/index.html">2000/tomx</a> is a notable counterexample).</li>
 <li>mentioning your name or any identifying information in the remark section (or
 in the C code for that matter) - we like to be unbiased during the judging
-rounds; we look at the author name only if an entry wins. See the guidelines if
-this is not clear!</li>
+rounds; we look at the author name only if an entry wins. See the
+<a href="next/guidelines.html">guidelines</a> <strong>AND</strong> <a href="next/rules.html">rules</a> if this is not clear!</li>
 <li>leaving the remark section empty.</li>
 </ul>
 <p>Jump to: <a href="#">top</a></p>
@@ -1114,7 +1113,7 @@ over there.</p>
 (although we hope you consider asking it in public for the benefit of others),
 then use the <a href="contact.html">How to contact the IOCCC</a> information to ask
 a private question.</p>
-<p><strong>IMPORTANT</strong>: When you ask your question (in public or as a private question)
+<p><strong>IMPORTANT NOTE</strong>: When you ask your question (in public or as a private question)
 <strong>PLEASE</strong> try to <strong>NOT</strong> discuss detailed information about any pending submission.
 Try to ask for question in a more generic way as this will help others
 with a similar question and this will not <strong>give away</strong> what you might be doing

--- a/faq.md
+++ b/faq.md
@@ -347,9 +347,10 @@ is only ready for submissions
 **ONLY WHEN THE CONTEST IS [open](status.html#open)**.
 
 See [current status of the IOCCC](status.html) for details on the contest status.
+
 **IMPORTANT NOTE**: When the contest is [closed](status.html#closed), the
 [IOCCC submit server](https://submit.ioccc.org)
-may be offline and unreachable as a web site.
+might be offline and unreachable as a website.
 
 **NOTE**: if you do need to update a submission, you might find the
 FAQ on "[how to not have to re-enter information more than once](#answers_file)"
@@ -392,7 +393,7 @@ code, your Makefile, your remarks, any other data files you wish to provide (up
 to a maximum, including the mandatory files, defined in
 [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)
 as `MAX_FILE_COUNT`) and other information about your submission,
-information about the author (or authors), and then runs a lot of tests before (if
+information about the author (or authors), and then it runs a lot of tests before (if
 all is OK) forming your tarball. After this is done it will additionally run the
 `txzchk(1)` tool (which runs the `fnamchk(1)` tool) on the submission tarball.
 The tool `chkentry(1)` will also be run, before creating the tarball. See the
@@ -506,7 +507,7 @@ be the _subdirectory_ with your submission's files**.
 The `mkiocccentry(1)` tool will ask you for information about your
 submission _as well as author details_ (that will only be looked at if the
 submission wins), run some tests and run a number of other tools, as briefly
-mentioned, and as described in the
+mentioned earlier, and as described in the
 "[finer details](#mkiocccentry_details)" section.
 
 See also the
@@ -538,8 +539,7 @@ Jump to: [top](#)
 </div>
 </div>
 
-We recommend starting with the [sample
-Makefile](next/Makefile.example)
+We recommend starting with the sample
 (renamed as `Makefile` of course) as a starting point for your
 entry's `Makefile`:
 
@@ -649,8 +649,8 @@ it, not very obfuscated entries have a minuscule chance to win (although
 [2000/tomx](2000/tomx/index.html) is a notable counterexample).
 - mentioning your name or any identifying information in the remark section (or
 in the C code for that matter) - we like to be unbiased during the judging
-rounds; we look at the author name only if an entry wins. See the guidelines if
-this is not clear!
+rounds; we look at the author name only if an entry wins. See the
+[guidelines](next/guidelines.html) **AND** [rules](next/rules.html) if this is not clear!
 - leaving the remark section empty.
 
 Jump to: [top](#)
@@ -880,7 +880,7 @@ If you do not feel, for some reason, comfortable asking your question in public
 then use the [How to contact the IOCCC](contact.html) information to ask
 a private question.
 
-**IMPORTANT**: When you ask your question (in public or as a private question)
+**IMPORTANT NOTE**: When you ask your question (in public or as a private question)
 **PLEASE** try to **NOT** discuss detailed information about any pending submission.
 Try to ask for question in a more generic way as this will help others
 with a similar question and this will not **give away** what you might be doing

--- a/inc/index.html
+++ b/inc/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/inc/topbar.default.html
+++ b/inc/topbar.default.html
@@ -106,8 +106,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="%%DOCROOT_SLASH%%faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="%%DOCROOT_SLASH%%faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -274,8 +274,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="%%DOCROOT_SLASH%%faq.html#compiling">

--- a/index.html
+++ b/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/judges.html
+++ b/judges.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/license.html
+++ b/license.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/location.html
+++ b/location.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/markdown.html
+++ b/markdown.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">
@@ -431,7 +431,7 @@
 <h2 id="ioccc-markdown-guidelines-version">IOCCC Markdown guidelines version</h2>
 </div>
 <p class="leftbar">
-These <a href="markdown.html">IOCCC markdown guidelines</a> are version <strong>28.0 2024-10-25</strong>.
+These <a href="markdown.html">IOCCC markdown guidelines</a> are version <strong>28.1 2024-12-27</strong>.
 </p>
 <p><strong>IMPORTANT</strong>: Be sure to read the <a href="next/rules.html">IOCCC rules</a> and <a href="next/guidelines.html">IOCCC
 guidelines</a>.</p>
@@ -809,7 +809,10 @@ italic</em></strong>.</p>
 <pre><code>     **_this text is bold italic_**</code></pre>
 <p>or:</p>
 <pre><code>     _**this text is bold italic**_</code></pre>
-<!-- AFTER: last line of markdown file: markdown.md -->
+<p><strong>BTW</strong>: the astute reader might notice that some cases of <code>*</code> for italic might
+have slipped through. We do ask you, however, to please observe this rule, as
+best you can.
+<!-- AFTER: last line of markdown file: markdown.md --></p>
 
 <!-- END: this line ends content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->
 <!-- START: this line starts content from: inc/after-content.default.html -->

--- a/markdown.md
+++ b/markdown.md
@@ -7,7 +7,7 @@
 </div>
 
 <p class="leftbar">
-These [IOCCC markdown guidelines](markdown.html) are version **28.0 2024-10-25**.
+These [IOCCC markdown guidelines](markdown.html) are version **28.1 2024-12-27**.
 </p>
 
 **IMPORTANT**: Be sure to read the [IOCCC rules](next/rules.html) and [IOCCC
@@ -692,3 +692,7 @@ or:
 ``` <!---markdown-->
      _**this text is bold italic**_
 ```
+
+**BTW**: the astute reader might notice that some cases of `*` for italic might
+have slipped through. We do ask you, however, to please observe this rule, as
+best you can.

--- a/news.html
+++ b/news.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">
@@ -457,7 +457,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 </div>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.28 2024-12-07</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.29 2024-12-27</strong>.
 </p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
@@ -511,6 +511,11 @@ The submit URL should be active on or slightly before <strong>2024-MMM-DD HH:MM:
 <strong>XXX - date/time is TBD - XXX</strong>
 </p>
 <p class="leftbar">
+See the
+FAQ on “<a href="../faq.html#enter">how to register and submit to the IOCCC</a>”
+for instructions on registering and participating in the IOCCC, as the process has changed from previous years!
+</p>
+<p class="leftbar">
 The <a href="rules.html">IOCCC rules</a> and these <a href="guidelines.html">IOCCC
 guidelines</a> will be available on the <a href="https://www.ioccc.org">Official IOCCC
 website</a> on or slightly before start of this IOCCC. Please check our
@@ -544,6 +549,11 @@ to account for the new <a href="https://github.com/ioccc-src/mkiocccentry">mkioc
 <p class="leftbar">
 The IOCCC submission URL, <a href="../status.html#open">when the IOCCC is open</a>, is
 <a href="https://submit.ioccc.org/">submit.ioccc.org</a>.
+</p>
+<p class="leftbar">
+Because the Judges send you your initial login and password, and because it will
+not be immediate, you should <strong>MAKE SURE</strong> you give yourself enough time before
+the contest closes. In other words, don’t wait until the last few days!
 </p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="hints">

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -43,7 +43,7 @@ Jump to: [top](#)
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.28 2024-12-07**.
+These [IOCCC guidelines](guidelines.html) are version **28.29 2024-12-27**.
 </p>
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
@@ -112,6 +112,12 @@ The submit URL should be active on or slightly before **2024-MMM-DD HH:MM:SS UTC
 </p>
 
 <p class="leftbar">
+See the
+FAQ on "[how to register and submit to the IOCCC](../faq.html#enter)"
+for instructions on registering and participating in the IOCCC, as the process has changed from previous years!
+</p>
+
+<p class="leftbar">
 The [IOCCC rules](rules.html) and these [IOCCC
 guidelines](guidelines.html) will be available on the [Official IOCCC
 website](https://www.ioccc.org) on or slightly before start of this IOCCC.  Please check our
@@ -152,6 +158,12 @@ to account for the new [mkiocccentry repo](https://github.com/ioccc-src/mkioccce
 <p class="leftbar">
 The IOCCC submission URL, [when the IOCCC is open](../status.html#open), is
 [submit.ioccc.org](https://submit.ioccc.org/).
+</p>
+
+<p class="leftbar">
+Because the Judges send you your initial login and password, and because it will
+not be immediate, you should **MAKE SURE** you give yourself enough time before
+the contest closes. In other words, don't wait until the last few days!
 </p>
 
 Jump to: [top](#)

--- a/next/index.html
+++ b/next/index.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/next/pw-change.html
+++ b/next/pw-change.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/next/register.html
+++ b/next/register.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">
@@ -473,7 +473,7 @@ you have tried a few times, <a href="../contact.html">Contact the IOCCC</a> to a
  alt="Subscription consent email"
  width=590 height=253></p>
 <p><strong>NOTE</strong>: If you prefer to <strong>NOT</strong> click links in email, simply copy that
-URL from your “Subscription consent email” and paste it into your browser. The</p>
+URL from your “Subscription consent email” and paste it into your browser.</p>
 <div id="step_d">
 <h2 id="step-d-confirm-your-email-click">Step D: Confirm your email click</h2>
 </div>
@@ -534,7 +534,7 @@ or <a href="../status.html#open">open</a>.</p>
 <p>While the contest is <strong><a href="../status.html#pending">PENDING</a></strong>,
 you may <strong>register for contest</strong>, however you will <strong>NOT</strong>
 receive an email message containing your <a href="https://submit.ioccc.org">IOCCC submit server</a>
-<strong>Username and Initial Password until the IOCCC is <a href="../status.html#open">open</a></strong>.</p>
+<em>Username and Initial Password</em> <strong>until the IOCCC is <a href="../status.html#open">open</a></strong>.</p>
 <h3 id="when-the-ioccc-status-is-open">When the IOCCC status is <em>open</em></h3>
 <p>While the contest is <strong><a href="../status.html#open">OPEN</a></strong>,
 you may <strong>register for the contest</strong>. Once you are registered <strong>AND</strong>

--- a/next/register.md
+++ b/next/register.md
@@ -67,7 +67,7 @@ Click on that link. The email might look the below:
  width=590 height=253>
 
 **NOTE**: If you prefer to **NOT** click links in email, simply copy that
-URL from your "Subscription consent email" and paste it into your browser. The
+URL from your "Subscription consent email" and paste it into your browser.
 
 
 <div id="step_d">
@@ -159,7 +159,7 @@ or [open](../status.html#open).
 While the contest is **[PENDING](../status.html#pending)**,
 you may **register for contest**, however you will **NOT**
 receive an email message containing your [IOCCC submit server](https://submit.ioccc.org)
-**Username and Initial Password until the IOCCC is [open](../status.html#open)**.
+*Username and Initial Password* **until the IOCCC is [open](../status.html#open)**.
 
 
 ### When the IOCCC status is _open_

--- a/next/rules.html
+++ b/next/rules.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/next/submit.html
+++ b/next/submit.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="../faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="../faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="../faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../faq.html#compiling">

--- a/nojs-menu.html
+++ b/nojs-menu.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">
@@ -445,7 +445,7 @@
 <h2 id="faq">FAQ</h2>
 <ul>
 <li><a href="faq.html">Frequently Asked Questions</a></li>
-<li><a href="faq.html#enter">How to enter</a></li>
+<li><a href="faq.html#enter">Enter the IOCCC</a></li>
 <li><a href="faq.html#compiling">Compiling entries</a></li>
 <li><a href="faq.html#running_entries">Running entries</a></li>
 <li><a href="faq.html#help">How to help</a></li>

--- a/nojs-menu.md
+++ b/nojs-menu.md
@@ -20,7 +20,7 @@
 ## FAQ
 
 * [Frequently Asked Questions](faq.html)
-* [How to enter](faq.html#enter)
+* [Enter the IOCCC](faq.html#enter)
 * [Compiling entries](faq.html#compiling)
 * [Running entries](faq.html#running_entries)
 * [How to help](faq.html#help)

--- a/status.html
+++ b/status.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">
@@ -5074,8 +5074,8 @@ compile or not work in some way. These are noted above as well.</p>
 <p>Where useful he added some notes to the Makefiles during compilation to let one
 know of certain problems or features that matter for instance having to disable
 the optimiser or in one case enabling <code>-g</code>.</p>
-<p>Also, rather than check <code>$(CC)</code> for exact matches of <code>gcc</code> or <code>clang</code> it now is
-that if <code>$(CC)</code> contains <code>gcc</code> or contains <code>clang</code> then the specific actions
+<p>Also, rather than check <code>${CC}</code> for exact matches of <code>gcc</code> or <code>clang</code> it now is
+that if <code>${CC}</code> contains <code>gcc</code> or contains <code>clang</code> then the specific actions
 related to the specific compiler will be done (priority is <code>gcc</code> then <code>clang</code>). This
 is useful because it’s not guaranteed that the compiler names for <code>gcc</code> or
 <code>clang</code> will be exactly that; in macOS for instance it can happen that they are
@@ -5088,19 +5088,13 @@ optimiser to fix an entry, sometimes causing other problems that also had to be
 fixed, a good example being <a href="#1986_marshall">1986/marshall</a> (see the
 <a href="1986/marshall/compilers.html">compilers.html</a> for the amusing details and all that
 had to be done to fix it).</p>
-<p>There was a ‘problem’ where <code>${MAKE}</code> was <code>$(MAKE)</code>: this doesn’t break anything
-but it is inconsistent with the rest of the <code>${foo}</code> tools even if by tradition
-it is <code>$(MAKE)</code>.</p>
 <p>Cody also added missing variables like <code>BASH</code> and <code>PDFLATEX</code> to the
 <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/var.mk">var.mk</a> file and removed another that was deemed problematic or
 undesired. Other variable names had typos in them.</p>
 <p>In at least one case, like the <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/Makefile">top level Makefile</a>, where raw
 commands that are in <a href="https://github.com/ioccc-src/temp-test-ioccc/blob/master/var.mk">var.mk</a> were used, Cody updated them to use the
 variables.</p>
-<p>A comment was missing for the <code>diff_alt_orig</code> rule in all the Makefiles and
-this, along with many other fixes and changes to the Makefiles were made by
-Cody’s <a href="https://github.com/xexyl/sgit">sgit tool</a> but many other changes he did
-manually.</p>
+<p>Some comments were fixed or added where it was deemed useful.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="consistency_improvements">
 <h2 id="consistency-improvements">Consistency improvements</h2>
@@ -5115,9 +5109,6 @@ some other files to markdown as well as format fixing them.</p>
 across the entries of all the years as well as other files. This is not possible
 for everything (the remarks of authors, for instance, cannot be and should not
 be made consistent but adding markdown where necessary in the remarks is).</p>
-<p>Some of these fixes were done with his <a href="https://github.com/xexyl/sgit">sgit
-tool</a> as well but the vast majority were done
-manually.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="try">
 <h2 id="try-script-system">Try script system</h2>
@@ -5138,10 +5129,13 @@ presentation of the winning entries.</p>
 <ul>
 <li>converting old hints files to README.md files (fixing problems in the process)</li>
 <li>converting other files to markdown</li>
-<li>extending the stylesheet for a few improvements</li>
+<li>extending / improving the stylesheet</li>
 <li>fixing many different kinds of problems in many files</li>
-<li>writing a few <a href="bin/index.html">website scripts</a>, improving a few others as
-well as identifying and/or fixing bugs in others</li>
+<li>writing a few <a href="bin/index.html">website scripts</a>, improving a few others,
+identifying bugs in some and fixing bugs in others</li>
+<li>co-developing the JSON parser <a href="https://github.com/xexyl/jparse">jparse</a> and
+tools (that the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> clones)
+with us, as we now make extensive use of JSON for the website</li>
 <li>greatly improving the manifest of the winning entries so that the links to the
 files in the index.html files make more sense and are consistent (although it
 might be said that some of them will not make sense if you don’t understand the
@@ -5206,13 +5200,13 @@ inconsistent award titles in the <code>README.md</code> files (that we use to ge
 run <code>sed(1)</code> on specified files under git that we sometimes use to edit the
 website, greatly improved the manifests and checked that the generated html
 files look good and are presentable, suggested CSS rules for
-image responsiveness (and other CSS improvements) and he greatly improved the FAQ.</p>
+image responsiveness (and made other CSS improvements) and he greatly improved the FAQ.</p>
 <p>Cody also wrote some of the <a href="bin/index.html">website scripts</a>, improved and
 bug fixed others, co-developed the <a href="https://github.com/xexyl/jparse">JSON parser and tools</a> with
 us, as we now make extensive use of JSON, and helped test and fix the submit
 server and mailing list for IOCCC28 and beyond.</p>
 <p><strong>THANK YOU VERY MUCH</strong> for your extensive efforts in helping improve the IOCCC
-presentation of past IOCCC entries, fixing almost all entries that no
+presentation of past IOCCC entries, fixing many entries that no
 longer worked and getting the IOCCC where it is today!</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="yusuke">

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -6971,8 +6971,8 @@ Where useful he added some notes to the Makefiles during compilation to let one
 know of certain problems or features that matter for instance having to disable
 the optimiser or in one case enabling `-g`.
 
-Also, rather than check `$(CC)` for exact matches of `gcc` or `clang` it now is
-that if `$(CC)` contains `gcc` or contains `clang` then the specific actions
+Also, rather than check `${CC}` for exact matches of `gcc` or `clang` it now is
+that if `${CC}` contains `gcc` or contains `clang` then the specific actions
 related to the specific compiler will be done (priority is `gcc` then `clang`). This
 is useful because it's not guaranteed that the compiler names for `gcc` or
 `clang` will be exactly that; in macOS for instance it can happen that they are
@@ -6987,10 +6987,6 @@ fixed, a good example being [1986/marshall](#1986_marshall) (see the
 [compilers.html](1986/marshall/compilers.html) for the amusing details and all that
 had to be done to fix it).
 
-There was a 'problem' where `${MAKE}` was `$(MAKE)`: this doesn't break anything
-but it is inconsistent with the rest of the `${foo}` tools even if by tradition
-it is `$(MAKE)`.
-
 Cody also added missing variables like `BASH` and `PDFLATEX` to the
 [var.mk](%%REPO_URL%%/var.mk) file and removed another that was deemed problematic or
 undesired. Other variable names had typos in them.
@@ -6999,10 +6995,7 @@ In at least one case, like the [top level Makefile](%%REPO_URL%%/Makefile), wher
 commands that are in [var.mk](%%REPO_URL%%/var.mk) were used, Cody updated them to use the
 variables.
 
-A comment was missing for the `diff_alt_orig` rule in all the Makefiles and
-this, along with many other fixes and changes to the Makefiles were made by
-Cody's [sgit tool](https://github.com/xexyl/sgit) but many other changes he did
-manually.
+Some comments were fixed or added where it was deemed useful.
 
 Jump to: [top](#)
 
@@ -7022,10 +7015,6 @@ Where possible he made the presentation of the entries much more consistent
 across the entries of all the years as well as other files. This is not possible
 for everything (the remarks of authors, for instance, cannot be and should not
 be made consistent but adding markdown where necessary in the remarks is).
-
-Some of these fixes were done with his [sgit
-tool](https://github.com/xexyl/sgit) as well but the vast majority were done
-manually.
 
 Jump to: [top](#)
 
@@ -7056,10 +7045,13 @@ Jump to: [top](#)
 
 - converting old hints files to README.md files (fixing problems in the process)
 - converting other files to markdown
-- extending the stylesheet for a few improvements
+- extending / improving the stylesheet
 - fixing many different kinds of problems in many files
-- writing a few [website scripts](bin/index.html), improving a few others as
-well as identifying and/or fixing bugs in others
+- writing a few [website scripts](bin/index.html), improving a few others,
+identifying bugs in some and fixing bugs in others
+- co-developing the JSON parser [jparse](https://github.com/xexyl/jparse)  and
+tools (that the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) clones)
+with us, as we now make extensive use of JSON for the website
 - greatly improving the manifest of the winning entries so that the links to the
 files in the index.html files make more sense and are consistent (although it
 might be said that some of them will not make sense if you don't understand the
@@ -7147,7 +7139,7 @@ He also wrote the feature-rich [sgit](https://github.com/xexyl/sgit) to easily
 run `sed(1)` on specified files under git that we sometimes use to edit the
 website, greatly improved the manifests and checked that the generated html
 files look good and are presentable, suggested CSS rules for
-image responsiveness (and other CSS improvements) and he greatly improved the FAQ.
+image responsiveness (and made other CSS improvements) and he greatly improved the FAQ.
 
 Cody also wrote some of the [website scripts](bin/index.html), improved and
 bug fixed others, co-developed the [JSON parser and tools](https://github.com/xexyl/jparse) with
@@ -7155,7 +7147,7 @@ us, as we now make extensive use of JSON, and helped test and fix the submit
 server and mailing list for IOCCC28 and beyond.
 
 **THANK YOU VERY MUCH** for your extensive efforts in helping improve the IOCCC
-presentation of past IOCCC entries, fixing almost all entries that no
+presentation of past IOCCC entries, fixing many entries that no
 longer worked and getting the IOCCC where it is today!
 
 

--- a/years.html
+++ b/years.html
@@ -150,8 +150,8 @@
             </div>
 
             <div class="outfit-font">
-              <a href="./faq.html#submit" class="sub-item-link">
-                How to enter
+              <a href="./faq.html#enter" class="sub-item-link">
+                Enter the IOCCC
               </a>
             </div>
 
@@ -318,8 +318,8 @@
               Frequently Asked Questions
             </a>
 
-            <a class="mobile-submenu-item" href="./faq.html#submit">
-              How to enter
+            <a class="mobile-submenu-item" href="./faq.html#enter">
+              Enter the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="./faq.html#compiling">


### PR DESCRIPTION
The menu in all html pages for the FAQ was fixed to link to the step 0 (of how to enter the contest) and also it was renamed ('Enter the IOCCC').

I also went through the most important sections of the FAQ (how to enter and the mkiocccentry related questions) and checked the register.html, pw-change.html and submit.html pages. It is possible I have missed something but I think it's in pretty good shape nonetheless.